### PR TITLE
Create query api for connector sources

### DIFF
--- a/connector/serializers.py
+++ b/connector/serializers.py
@@ -2,14 +2,13 @@ from drf_dynamic_fields import DynamicFieldsMixin
 from rest_framework import serializers
 
 from deep.serializers import RemoveNullFieldsMixin
+from user_resource.serializers import UserResourceSerializer
 from lead.models import Lead
 from .models import (
     Connector,
     ConnectorUser,
     ConnectorProject,
 )
-
-from user_resource.serializers import UserResourceSerializer
 
 
 class SourceOptionSerializer(RemoveNullFieldsMixin,

--- a/connector/sources/rss_feed.py
+++ b/connector/sources/rss_feed.py
@@ -71,3 +71,10 @@ class RssFeed(Source):
             results.append(data)
 
         return results
+
+    def query_fields(self, params):
+        if not params or not params.get('feed-url'):
+            return []
+
+        feed = feedparser.parse(params['feed-url'])
+        return list(feed.entries[0].keys())

--- a/connector/views.py
+++ b/connector/views.py
@@ -1,8 +1,9 @@
 from rest_framework import (
-    viewsets,
-    response,
-    permissions,
     exceptions,
+    permissions,
+    response,
+    views,
+    viewsets,
 )
 from rest_framework.decorators import detail_route
 from deep.permissions import ModifyPermission
@@ -33,6 +34,23 @@ class SourceViewSet(viewsets.ViewSet):
             'count': len(results),
             'results': results,
         })
+
+
+class SourceQueryView(views.APIView):
+    permission_classes = [permissions.IsAuthenticated]
+
+    def get(self, request, source_type, query, version=None):
+        source = source_store[source_type]()
+        method = getattr(source, 'query_{}'.format(query))
+        results = method(request.GET)
+
+        if isinstance(results, list):
+            return response.Response({
+                'count': len(results),
+                'results': results,
+            })
+
+        return response.Response(results)
 
 
 class ConnectorViewSet(viewsets.ModelViewSet):

--- a/deep/urls.py
+++ b/deep/urls.py
@@ -80,6 +80,7 @@ from category_editor.views import (
 )
 from connector.views import (
     SourceViewSet,
+    SourceQueryView,
     ConnectorViewSet,
     ConnectorUserViewSet,
     ConnectorProjectViewSet,
@@ -300,6 +301,11 @@ urlpatterns = [
     url(get_api_path(
         r'projects/(?P<project_id>\d+)/category-editor/classify/'
     ), CategoryEditorClassifyView.as_view()),
+
+    # Source query api
+    url(get_api_path(
+        r'connector-sources/(?P<source_type>[-\w]+)/(?P<query>[-\w]+)/',
+    ), SourceQueryView.as_view()),
 
     # Geojson api
     url(get_api_path(r'admin-levels/(?P<admin_level_id>\d+)/geojson/$'),


### PR DESCRIPTION
Following query has been implemented:

- rss-feed/fields: takes in `feed-url` param and generate a list
  of fields available from the rss-feed