### PR TITLE
Update all projects' statuses whenever `ProjectStatus` data changes

### DIFF
--- a/bulk_data_migration/v1_2/migrate.py
+++ b/bulk_data_migration/v1_2/migrate.py
@@ -1,9 +1,10 @@
 from analysis_framework.utils import update_widgets, Widget
 from entry.utils import update_attributes, Attribute
 
+from .projects import migrate_projects
 from . import (
     matrix1d,
-    matrix2d, # TODO Check for subsectors
+    matrix2d,
     scale,
     excerpt,
     organigram,
@@ -71,6 +72,7 @@ def migrate_attributes():
 
 
 def migrate():
+    migrate_projects()
     migrate_widgets()
     migrate_attributes()
     update_widgets()

--- a/bulk_data_migration/v1_2/projects.py
+++ b/bulk_data_migration/v1_2/projects.py
@@ -1,0 +1,8 @@
+from django.db import transaction
+from project.models import Project
+
+
+def migrate_projects():
+    with transaction.atomic():
+        for project in Project.objects.all():
+            project.update_status()

--- a/entry/models.py
+++ b/entry/models.py
@@ -187,6 +187,7 @@ class ExportData(models.Model):
 
 @receiver(models.signals.post_save, sender=Entry)
 def on_entry_saved(sender, **kwargs):
-    project = kwargs.get('instance').lead.project
-    project.status = project.calc_status()
-    project.save()
+    lead = kwargs.get('instance').lead
+    # TODO After `project` is added to Entry
+    # this should not use lead
+    lead.project.update_status()

--- a/lead/models.py
+++ b/lead/models.py
@@ -198,5 +198,4 @@ class LeadPreviewImage(models.Model):
 @receiver(models.signals.post_save, sender=Lead)
 def on_lead_saved(sender, **kwargs):
     project = kwargs.get('instance').project
-    project.status = project.calc_status()
-    project.save()
+    project.update_status()

--- a/project/models.py
+++ b/project/models.py
@@ -342,8 +342,10 @@ def on_membership_saved(sender, **kwargs):
     )
 
 
-# Whenever a project status value is changed, update all projects' status
+# Whenever a project status value is changed, update all projects' statuses
 @receiver(models.signals.post_save, sender=ProjectStatus)
+@receiver(models.signals.post_delete, sender=ProjectStatus)
+@receiver(models.signals.post_save, sender=ProjectStatusCondition)
 def on_status_updated(sender, **kwargs):
     with transaction.atomic():
         for project in Project.objects.all():


### PR DESCRIPTION
Also use `update` in different signal receivers to prevent updating modified time.