### PR TITLE
Remove `number_of_users` from annotated projects

### DIFF
--- a/project/serializers.py
+++ b/project/serializers.py
@@ -76,7 +76,10 @@ class ProjectSerializer(RemoveNullFieldsMixin,
         read_only=True,
     )
 
-    number_of_users = serializers.IntegerField(read_only=True)
+    number_of_users = serializers.IntegerField(
+        source='get_number_of_users',
+        read_only=True,
+    )
     number_of_leads = serializers.IntegerField(read_only=True)
     number_of_entries = serializers.IntegerField(read_only=True)
 


### PR DESCRIPTION
Fix for alpha bug where server freezes when querying projects with the number of users. The fix is to remove annotated query for number of users from project so that the final query doesn't freeze the db server.