### PR TITLE
Fix user member-of api permission

### DIFF
--- a/apps/project/models.py
+++ b/apps/project/models.py
@@ -235,6 +235,12 @@ class Project(UserResource):
         return Project.objects.exclude(Q(is_private=True) & ~Q(members=user))
 
     @staticmethod
+    def get_for_public(requestUser, user):
+        return Project\
+            .get_for_member(user)\
+            .exclude(models.Q(is_private=True) & ~models.Q(members=requestUser))
+
+    @staticmethod
     def get_for_member(user, annotated=False):
         # FIXME: get viewable projects
         # Also, pick only required fields instead of annotating everytime.

--- a/apps/project/views.py
+++ b/apps/project/views.py
@@ -92,8 +92,13 @@ class ProjectViewSet(viewsets.ModelViewSet):
         url_path='member-of',
     )
     def get_for_member(self, request, version=None):
-        user = self.request.GET.get('user', request.user)
+        user = self.request.GET.get('user')
         projects = Project.get_for_member(user)
+
+        if user is None or request.user == user:
+            projects = Project.get_for_member(request.user)
+        else:
+            projects = Project.get_for_public(request.user, user)
 
         user_group = request.GET.get('user_group')
         if user_group:


### PR DESCRIPTION
Changes:

Previously, the api `member-of/` will pull all the projects (even the private ones) when viewed by another user (in User profile page). This behaviour has been fixed.

Summary: requestor will only see the user's private project in the listing if the requestor also has access to that private project