### PR TITLE
Feature/bulk lead delete

### DIFF
--- a/apps/lead/models.py
+++ b/apps/lead/models.py
@@ -238,6 +238,16 @@ class Lead(UserResource, ProjectEntityMixin):
             return self.author and self.author.data.title
         return self.author_raw
 
+    @classmethod
+    def get_associated_entities(cls, lead_ids):
+        """
+        Used for pre-check before deletion
+        """
+        from entry.models import Entry
+        return {
+            'entries': Entry.objects.filter(lead__in=lead_ids).count()
+        }
+
 
 class LeadPreview(models.Model):
     STATUS_CLASSIFICATION_NONE = 'none'  # For leads which are not texts

--- a/apps/lead/models.py
+++ b/apps/lead/models.py
@@ -244,8 +244,10 @@ class Lead(UserResource, ProjectEntityMixin):
         Used for pre-check before deletion
         """
         from entry.models import Entry
+        from ary.models import Assessment
         return {
-            'entries': Entry.objects.filter(lead__in=lead_ids).count()
+            'entries': Entry.objects.filter(lead__in=lead_ids).count(),
+            'assessments': Assessment.objects.filter(lead__in=lead_ids).count(),
         }
 
 

--- a/apps/lead/models.py
+++ b/apps/lead/models.py
@@ -239,15 +239,15 @@ class Lead(UserResource, ProjectEntityMixin):
         return self.author_raw
 
     @classmethod
-    def get_associated_entities(cls, lead_ids):
+    def get_associated_entities(cls, project_id, lead_ids):
         """
         Used for pre-check before deletion
         """
         from entry.models import Entry
         from ary.models import Assessment
         return {
-            'entries': Entry.objects.filter(lead__in=lead_ids).count(),
-            'assessments': Assessment.objects.filter(lead__in=lead_ids).count(),
+            'entries': Entry.objects.filter(lead__in=lead_ids, lead__project_id=project_id).count(),
+            'assessments': Assessment.objects.filter(lead__project_id=project_id, lead__in=lead_ids).count(),
         }
 
 

--- a/apps/lead/tests/test_apis.py
+++ b/apps/lead/tests/test_apis.py
@@ -92,7 +92,7 @@ class LeadTests(TestCase):
         lead_ids = [str(lead1.id), str(lead3.id)]
         admin_user = self.create(User)
         project.add_member(admin_user, role=self.admin_role)
-        url = '/api/v1/leads/pre-bulk-delete/'
+        url = '/api/v1/leads/dry-bulk-delete/'
         self.authenticate(admin_user)
         response = self.client.post(url, {'ids': ','.join(lead_ids)})
         self.assert_200(response)

--- a/apps/lead/tests/test_apis.py
+++ b/apps/lead/tests/test_apis.py
@@ -111,7 +111,7 @@ class LeadTests(TestCase):
         project.add_member(admin_user, role=self.admin_role)
         url = '/api/v1/leads/bulk-delete/'
         self.authenticate(admin_user)
-        response = self.client.delete(url, {'project': project.id,
+        response = self.client.post(url, {'project': project.id,
                                             'ids': ','.join(lead_ids)})
         self.assert_204(response)
 

--- a/apps/lead/views.py
+++ b/apps/lead/views.py
@@ -243,7 +243,7 @@ class LeadViewSet(viewsets.ModelViewSet):
     @action(
         detail=False,
         permission_classes=[DeleteLeadPermission],
-        methods=['DELETE'],
+        methods=['POST'],
         url_path='bulk-delete'
     )
     def leads_bulk_delete(self, request, version=None):

--- a/apps/lead/views.py
+++ b/apps/lead/views.py
@@ -233,7 +233,7 @@ class LeadViewSet(viewsets.ModelViewSet):
         detail=False,
         permission_classes=[permissions.IsAuthenticated],
         methods=['POST'],
-        url_path='pre-bulk-delete'
+        url_path='dry-bulk-delete'
     )
     def leads_pre_delete(self, request, version=None):
         lead_ids = [int(each) for each in request.data.get('ids', '').split(',')]

--- a/apps/lead/views.py
+++ b/apps/lead/views.py
@@ -229,26 +229,28 @@ class LeadViewSet(viewsets.ModelViewSet):
                 filter_data[key] = value
         return filter_data
 
+
+class LeadBulkDeleteViewSet(viewsets.GenericViewSet):
+    permission_classes = [DeleteLeadPermission]
+
     @action(
         detail=False,
-        permission_classes=[permissions.IsAuthenticated],
-        methods=['POST'],
-        url_path='dry-bulk-delete'
+        methods=['post'],
+        url_path='dry-bulk-delete',
     )
-    def leads_pre_delete(self, request, version=None):
-        lead_ids = [int(each) for each in request.data.get('ids', '').split(',')]
-        tbd_entities = Lead.get_associated_entities(lead_ids)
+    def dry_bulk_delete(self, request, project_id, version=None):
+        lead_ids = request.data.get('leads', [])
+        tbd_entities = Lead.get_associated_entities(project_id, lead_ids)
         return response.Response(tbd_entities, status=status.HTTP_200_OK)
 
     @action(
         detail=False,
-        permission_classes=[DeleteLeadPermission],
-        methods=['POST'],
-        url_path='bulk-delete'
+        methods=['post'],
+        url_path='bulk-delete',
     )
-    def leads_bulk_delete(self, request, version=None):
-        lead_ids = [int(each) for each in request.data.get('ids', '').split(',')]
-        Lead.objects.filter(id__in=lead_ids).delete()
+    def bulk_delete(self, request, project_id, version=None):
+        lead_ids = request.data.get('leads', [])
+        Lead.objects.filter(project_id=project_id, id__in=lead_ids).delete()
         return response.Response(status=status.HTTP_204_NO_CONTENT)
 
 

--- a/deep/permissions.py
+++ b/deep/permissions.py
@@ -68,41 +68,25 @@ class CreateLeadPermission(permissions.BasePermission):
 class DeleteLeadPermission(permissions.BasePermission):
     """Checks if user can delete lead(s)"""
     def has_permission(self, request, view):
-        if request.method not in ('DELETE',):
+        if request.method not in ('POST', 'DELETE'):
             return True
 
-        project_id = request.data.get('project')
-        lead_ids = request.data.get('ids', '').split(',')
+        project_id = view.kwargs.get('project_id')
 
         if not project_id:
-            return False
-        if not lead_ids:
-            return True
-
-        # Since this supports list value for project
-        if isinstance(project_id, list):
-            project_ids = set(project_id)
-        else:
-            project_ids = {project_id}
-
-        lead_projects = set(Lead.objects.filter(id__in=lead_ids).values_list('project', flat=True))
-        if lead_projects.difference(project_ids):
-            # if lead being deleted project is not mentioned in project_ids
             return False
 
         delete_lead_perm_value = PROJECT_PERMISSIONS.lead.delete
 
         # Check if the user has delete permissions on all projects
-        projects_count = Project.objects.filter(
-            id__in=project_ids,
+        return Project.objects.filter(
+            id=project_id,
             projectmembership__member=request.user
         ).annotate(
             delete_lead=F('projectmembership__role__lead_permissions').bitand(delete_lead_perm_value)
         ).filter(
             delete_lead__gt=0,
-        ).count()
-
-        return projects_count == len(project_ids)
+        ).exists()
 
 
 class CreateEntryPermission(permissions.BasePermission):

--- a/deep/urls.py
+++ b/deep/urls.py
@@ -76,6 +76,7 @@ from questionnaire.views import (
 from lead.views import (
     LeadGroupViewSet,
     LeadViewSet,
+    LeadBulkDeleteViewSet,
     LeadPreviewViewSet,
     LeadOptionsView,
     LeadExtractionTriggerView,
@@ -246,6 +247,8 @@ router.register(r'lead-groups', LeadGroupViewSet,
                 basename='lead_group')
 router.register(r'leads', LeadViewSet,
                 basename='lead')
+router.register(r'project/(?P<project_id>\d+)/leads', LeadBulkDeleteViewSet,
+                basename='leads-bulk')
 router.register(r'lead-previews', LeadPreviewViewSet,
                 basename='lead_preview')
 


### PR DESCRIPTION
Bulk deleting leads

Endpoints:
```js
POST 
/api/v1/project/<PROJECT-ID>/leads/dry-bulk-delete/ 
data: {leads: <LIST of lead ids>}
response: number of entities that will cascade delete (for now: entries, assessments)

POST
/api/v1/project/<PROJECT-ID>/leads/bulk-delete/ 
data: {leads: <LIST of lead ids>}
response: 204 No Content
```
