### PR TITLE
Word Export: Limit the number of entries to 50 for preview

### DIFF
--- a/apps/export/assessments/excel_exporter.py
+++ b/apps/export/assessments/excel_exporter.py
@@ -153,7 +153,7 @@ class ExcelExporter:
 
             self._excel_rows.append(rows)
 
-    def export(self):
+    def export(self, is_preview=False):
         # Generate rows
         self.assessments_to_rows()
 
@@ -188,7 +188,10 @@ class ExcelExporter:
             self.split.set_col_types(self.col_types)
 
         buffer = self.wb.save()
-        filename = generate_filename('Assessments Export', 'xlsx')
+        if is_preview:
+            filename = generate_filename(' Preview Assessments Export', 'xlsx')
+        else:
+            filename = generate_filename('Assessments Export', 'xlsx')
         return filename, Export.XLSX, EXCEL_MIME_TYPE, ContentFile(buffer)
 
 
@@ -279,7 +282,7 @@ class NewExcelExporter:
                     row.extend(rowdata)
                 self.wb_sheets[sheet].append([row])
 
-    def export(self):
+    def export(self, is_preview=False):
         # Write cols header first
         self.add_headers()
 
@@ -291,5 +294,8 @@ class NewExcelExporter:
             self.wb.wb.remove(self.wb.wb.get_sheet_by_name('Sheet'))
 
         buffer = self.wb.save()
-        filename = generate_filename('Assessments Export', 'xlsx')
+        if is_preview:
+            filename = generate_filename('Preview Assessments Export', 'xlsx')
+        else:
+            filename = generate_filename('Assessments Export', 'xlsx')
         return filename, Export.XLSX, EXCEL_MIME_TYPE, ContentFile(buffer)

--- a/apps/export/assessments/excel_exporter.py
+++ b/apps/export/assessments/excel_exporter.py
@@ -14,6 +14,9 @@ logger = logging.getLogger('django')
 
 
 class ExcelExporter:
+    """
+    NOTE: Legacy exporter (Not used)
+    """
     def __init__(self, decoupled=True):
         self.wb = WorkBook()
 
@@ -153,7 +156,7 @@ class ExcelExporter:
 
             self._excel_rows.append(rows)
 
-    def export(self, is_preview=False):
+    def export(self):
         # Generate rows
         self.assessments_to_rows()
 
@@ -188,10 +191,7 @@ class ExcelExporter:
             self.split.set_col_types(self.col_types)
 
         buffer = self.wb.save()
-        if is_preview:
-            filename = generate_filename(' Preview Assessments Export', 'xlsx')
-        else:
-            filename = generate_filename('Assessments Export', 'xlsx')
+        filename = generate_filename('Assessments Export', 'xlsx')
         return filename, Export.XLSX, EXCEL_MIME_TYPE, ContentFile(buffer)
 
 
@@ -282,7 +282,7 @@ class NewExcelExporter:
                     row.extend(rowdata)
                 self.wb_sheets[sheet].append([row])
 
-    def export(self, is_preview=False):
+    def export(self):
         # Write cols header first
         self.add_headers()
 
@@ -294,8 +294,5 @@ class NewExcelExporter:
             self.wb.wb.remove(self.wb.wb.get_sheet_by_name('Sheet'))
 
         buffer = self.wb.save()
-        if is_preview:
-            filename = generate_filename('Preview Assessments Export', 'xlsx')
-        else:
-            filename = generate_filename('Assessments Export', 'xlsx')
+        filename = generate_filename('Assessments Export', 'xlsx')
         return filename, Export.XLSX, EXCEL_MIME_TYPE, ContentFile(buffer)

--- a/apps/export/entries/excel_exporter.py
+++ b/apps/export/entries/excel_exporter.py
@@ -464,7 +464,7 @@ class ExcelExporter:
                 [[author, source, published, f'=HYPERLINK("{url}", "{title}")' if url else title]]
             )
 
-    def export(self):
+    def export(self, is_preview=False):
         """
         Export and return export data
         """
@@ -476,5 +476,8 @@ class ExcelExporter:
         self.add_bibliography_sheet()
 
         buffer = self.wb.save()
-        filename = generate_filename('Entries Export', 'xlsx')
+        if is_preview:
+            filename = generate_filename('Preview Entries Export', 'xlsx')
+        else:
+            filename = generate_filename('Entries Export', 'xlsx')
         return filename, Export.XLSX, EXCEL_MIME_TYPE, ContentFile(buffer)

--- a/apps/export/entries/excel_exporter.py
+++ b/apps/export/entries/excel_exporter.py
@@ -15,7 +15,8 @@ EXPORT_DATE_FORMAT = '%m/%d/%y'
 
 
 class ExcelExporter:
-    def __init__(self, entries, decoupled=True, project_id=None):
+    def __init__(self, entries, decoupled=True, project_id=None, is_preview=False):
+        self.is_preview = is_preview
         self.wb = WorkBook()
         # XXX: Limit memory usage? (Or use redis?)
         self.geoarea_data_cache = {}
@@ -375,7 +376,8 @@ class ExcelExporter:
         return ''
 
     def add_entries(self, entries):
-        for i, entry in enumerate(entries):
+        iterable_entries = entries[:Export.PREVIEW_ENTRY_SIZE] if self.is_preview else entries
+        for i, entry in enumerate(iterable_entries):
             # Export each entry
             # Start building rows and export data for each exportable
 
@@ -464,7 +466,7 @@ class ExcelExporter:
                 [[author, source, published, f'=HYPERLINK("{url}", "{title}")' if url else title]]
             )
 
-    def export(self, is_preview=False):
+    def export(self):
         """
         Export and return export data
         """
@@ -476,8 +478,5 @@ class ExcelExporter:
         self.add_bibliography_sheet()
 
         buffer = self.wb.save()
-        if is_preview:
-            filename = generate_filename('Preview Entries Export', 'xlsx')
-        else:
-            filename = generate_filename('Entries Export', 'xlsx')
+        filename = generate_filename('Entries Export', 'xlsx')
         return filename, Export.XLSX, EXCEL_MIME_TYPE, ContentFile(buffer)

--- a/apps/export/entries/json_exporter.py
+++ b/apps/export/entries/json_exporter.py
@@ -67,14 +67,11 @@ class JsonExporter:
             self.data['entries'].append(data)
         return self
 
-    def export(self, is_preview=False):
+    def export(self):
         """
         Export and return export data
         """
-        if is_preview:
-            filename = generate_filename('Preview Entries JSON Export', 'json')
-        else:
-            filename = generate_filename('Entries JSON Export', 'json')
+        filename = generate_filename('Entries JSON Export', 'json')
         json_data = json.dumps(self.data, sort_keys=True, indent=2,
                                cls=DjangoJSONEncoder).encode('utf-8')
 

--- a/apps/export/entries/json_exporter.py
+++ b/apps/export/entries/json_exporter.py
@@ -64,12 +64,14 @@ class JsonExporter:
             self.data['entries'].append(data)
         return self
 
-    def export(self):
+    def export(self, is_preview=False):
         """
         Export and return export data
         """
-        filename = generate_filename('Entries JSON Export', 'json')
-
+        if is_preview:
+            filename = generate_filename('Preview Entries JSON Export', 'json')
+        else:
+            filename = generate_filename('Entries JSON Export', 'json')
         json_data = json.dumps(self.data, sort_keys=True, indent=2,
                                cls=DjangoJSONEncoder).encode('utf-8')
 

--- a/apps/export/entries/json_exporter.py
+++ b/apps/export/entries/json_exporter.py
@@ -10,7 +10,8 @@ import json
 
 
 class JsonExporter:
-    def __init__(self):
+    def __init__(self, is_preview=False):
+        self.is_preview = is_preview
         self.data = {}
 
     def load_exportables(self, exportables):
@@ -36,7 +37,9 @@ class JsonExporter:
 
     def add_entries(self, entries):
         self.data['entries'] = []
-        for entry in entries:
+
+        iterable_entries = entries[:Export.PREVIEW_ENTRY_SIZE] if self.is_preview else entries
+        for entry in iterable_entries:
             lead = entry.lead
             data = {}
             data['id'] = entry.id

--- a/apps/export/entries/report_exporter.py
+++ b/apps/export/entries/report_exporter.py
@@ -630,7 +630,7 @@ class ReportExporter:
 
         return self
 
-    def export(self, pdf=False):
+    def export(self, pdf=False, is_preview=False):
         """
         Export and return export data
         """
@@ -682,8 +682,10 @@ class ReportExporter:
 
             call(['libreoffice', '--headless', '--convert-to',
                   'pdf', temp_doc.name, '--outdir', settings.TEMP_DIR])
-
-            filename = generate_filename('Entries General Export', 'pdf')
+            if is_preview:
+                filename = generate_filename('Preview Entries General Export', 'pdf')
+            else:
+                filename = generate_filename('Entries General Export', 'pdf')
             file = File(open(temp_pdf, 'rb'))
             export_format = Export.PDF
             export_mime_type = PDF_MIME_TYPE
@@ -694,8 +696,10 @@ class ReportExporter:
 
         else:
             buffer = self.doc.save()
-
-            filename = generate_filename('Entries General Export', 'docx')
+            if is_preview:
+                filename = generate_filename('Preview Entries General Export', 'pdf')
+            else:
+                filename = generate_filename('Entries General Export', 'pdf')
             file = ContentFile(buffer)
             export_format = Export.DOCX
             export_mime_type = DOCX_MIME_TYPE

--- a/apps/export/entries/report_exporter.py
+++ b/apps/export/entries/report_exporter.py
@@ -696,7 +696,8 @@ class ReportExporter:
 
         else:
             buffer = self.doc.save()
-            filename = generate_filename('Entries General Export', 'pdf')
+
+            filename = generate_filename('Entries General Export', 'docx')
             file = ContentFile(buffer)
             export_format = Export.DOCX
             export_mime_type = DOCX_MIME_TYPE

--- a/apps/export/entries/report_exporter.py
+++ b/apps/export/entries/report_exporter.py
@@ -493,6 +493,7 @@ class ReportExporter:
             levels,
             level_entries_map,
             valid_levels,
+            is_preview,
             structures=None,
             heading_level=2,
     ):
@@ -517,6 +518,8 @@ class ReportExporter:
                 self.doc.add_paragraph()
 
             if entries:
+                if is_preview:
+                    [self._generate_for_entry(entry) for entry in entries[:50]]
                 [self._generate_for_entry(entry) for entry in entries]
 
             if sublevels:
@@ -535,11 +538,14 @@ class ReportExporter:
                     heading_level + 1,
                 )
 
-    def _generate_for_uncategorized(self, entries):
+    def _generate_for_uncategorized(self, entries, is_preview):
         entries = entries.exclude(
             Q(exportdata__data__report__keys__isnull=False) |
             Q(exportdata__data__report__keys__len__gt=0)
         )
+        if is_preview:
+            entries = entries[:50]
+
         if entries.count() == 0:
             return
 
@@ -561,7 +567,7 @@ class ReportExporter:
         self.legend_heading = self.doc.add_heading('Legends', 2)
         self.legend_paragraph = self.doc.add_paragraph()
 
-    def add_entries(self, entries):
+    def add_entries(self, entries, is_preview=False):
         """
         Add entries and generate parapgraphs for all entries
         """
@@ -614,11 +620,11 @@ class ReportExporter:
                 s.get('levels') for s in self.structure
                 if str(s['id']) == str(exportable.id)
             ), None)
-            self._generate_for_levels(levels, level_entries_map,
+            self._generate_for_levels(levels, level_entries_map, is_preview,
                                       valid_levels, structures)
 
         if uncategorized:
-            self._generate_for_uncategorized(entries)
+            self._generate_for_uncategorized(entries, is_preview)
         if entries:
             self._generate_legend_page(entries[0].project)
 

--- a/apps/export/filter_set.py
+++ b/apps/export/filter_set.py
@@ -21,7 +21,7 @@ class ExportFilterSet(django_filters.rest_framework.FilterSet):
 
     class Meta:
         model = Export
-        fields = ['is_preview']
+        fields = []
 
     def ordering_filter(self, qs, name, value):
         orderings = [x.strip() for x in value.split(',') if x.strip()]

--- a/apps/export/models.py
+++ b/apps/export/models.py
@@ -54,6 +54,8 @@ class Export(models.Model):
         (REPORT, 'Report'),
         (JSON, 'Json'),
     )
+    # Number of entries to proccess if is_preview is True
+    PREVIEW_ENTRY_SIZE = 50
 
     project = models.ForeignKey(
         Project, default=None, null=True, blank=True, on_delete=models.CASCADE,

--- a/apps/export/models.py
+++ b/apps/export/models.py
@@ -55,7 +55,8 @@ class Export(models.Model):
         (JSON, 'Json'),
     )
     # Number of entries to proccess if is_preview is True
-    PREVIEW_ENTRY_SIZE = 50
+    PREVIEW_ENTRY_SIZE = 10
+    PREVIEW_ASSESSMENT_SIZE = 10
 
     project = models.ForeignKey(
         Project, default=None, null=True, blank=True, on_delete=models.CASCADE,

--- a/apps/export/tasks/__init__.py
+++ b/apps/export/tasks/__init__.py
@@ -25,6 +25,7 @@ def export_task(export_id):
         export.save()
 
         filename, export_format, mime_type, file = EXPORTER_TYPE[export.type](export)
+        filename = f'Preview-{filename}' if export.is_preview else filename
 
         export.title = filename
         export.format = export_format

--- a/apps/export/tasks/tasks_assessment.py
+++ b/apps/export/tasks/tasks_assessment.py
@@ -11,6 +11,7 @@ from export.assessments import ExcelExporter, NewExcelExporter
 def export_assessments(export):
     project = export.project
     export_type = export.export_type
+    is_preview = export.is_preview
 
     arys = Assessment.objects.filter(lead__project=project).distinct()
     if export_type == Export.JSON:
@@ -23,7 +24,7 @@ def export_assessments(export):
     elif export_type == Export.EXCEL:
         sheets_data = get_export_data_for_assessments(arys)
         export_data = NewExcelExporter(sheets_data)\
-            .export()
+            .export(is_preview)
     else:
         raise Exception(
             '(Assessments Export) Unkown Export Type Provided: {} for Export:'.format(export_type, export.id),
@@ -35,6 +36,7 @@ def export_assessments(export):
 def export_planned_assessments(export):
     project = export.project
     export_type = export.export_type
+    is_preview = export.is_preview
 
     arys = PlannedAssessment.objects.filter(project=project).distinct()
     if export_type == Export.JSON:
@@ -47,7 +49,7 @@ def export_planned_assessments(export):
     elif export_type == Export.EXCEL:
         sheets_data = get_export_data_for_planned_assessments(arys)
         export_data = NewExcelExporter(sheets_data)\
-            .export()
+            .export(is_preview)
     else:
         raise Exception(
             '(Assessments Export) Unkown Export Type Provided: {} for Export:'.format(export_type, export.id),

--- a/apps/export/tasks/tasks_assessment.py
+++ b/apps/export/tasks/tasks_assessment.py
@@ -5,54 +5,38 @@ from ary.export import (
 )
 from export.models import Export
 from export.exporters import JsonExporter
-from export.assessments import ExcelExporter, NewExcelExporter
+from export.assessments import NewExcelExporter
 
 
-def export_assessments(export):
+def _export_assessments(export, AssessmentModel, excel_sheet_data_generator):
     project = export.project
     export_type = export.export_type
     is_preview = export.is_preview
 
-    arys = Assessment.objects.filter(lead__project=project).distinct()
-    if export_type == Export.JSON:
-        exporter = JsonExporter()
-        exporter.data = {
-            ary.lead.project.title: ary.to_exportable_json()
-            for ary in arys
-        }
-        export_data = exporter.export(export, export.type.title())
-    elif export_type == Export.EXCEL:
-        sheets_data = get_export_data_for_assessments(arys)
-        export_data = NewExcelExporter(sheets_data)\
-            .export(is_preview)
-    else:
-        raise Exception(
-            '(Assessments Export) Unkown Export Type Provided: {} for Export:'.format(export_type, export.id),
-        )
-
-    return export_data
-
-
-def export_planned_assessments(export):
-    project = export.project
-    export_type = export.export_type
-    is_preview = export.is_preview
-
-    arys = PlannedAssessment.objects.filter(project=project).distinct()
+    arys = AssessmentModel.objects.filter(project=project).prefetch_related('project').distinct()
+    iterable_arys = arys[:Export.PREVIEW_ASSESSMENT_SIZE] if is_preview else arys
     if export_type == Export.JSON:
         exporter = JsonExporter()
         exporter.data = {
             ary.project.title: ary.to_exportable_json()
-            for ary in arys
+            for ary in iterable_arys
         }
         export_data = exporter.export(export, export.type.title())
     elif export_type == Export.EXCEL:
-        sheets_data = get_export_data_for_planned_assessments(arys)
+        sheets_data = excel_sheet_data_generator(iterable_arys)
         export_data = NewExcelExporter(sheets_data)\
-            .export(is_preview)
+            .export()
     else:
         raise Exception(
-            '(Assessments Export) Unkown Export Type Provided: {} for Export:'.format(export_type, export.id),
+            f'(Assessments Export) Unkown Export Type Provided: {export_type} for Export: {export.id}'
         )
 
     return export_data
+
+
+def export_assessments(export):
+    return _export_assessments(export, Assessment, get_export_data_for_assessments)
+
+
+def export_planned_assessments(export):
+    return _export_assessments(export, PlannedAssessment, get_export_data_for_planned_assessments)

--- a/apps/export/tasks/tasks_entries.py
+++ b/apps/export/tasks/tasks_entries.py
@@ -14,6 +14,7 @@ def export_entries(export):
     user = export.exported_by
     project_id = export.project.id
     export_type = export.export_type
+    is_preview = export.is_preview
 
     filters = export.filters
     queryset = get_filtered_entries(user, filters).prefetch_related(
@@ -45,7 +46,7 @@ def export_entries(export):
         decoupled = filters.get('decoupled', True)
         export_data = ExcelExporter(queryset, decoupled, project_id)\
             .load_exportables(exportables, regions)\
-            .add_entries(queryset)\
+            .add_entries(queryset, is_preview)\
             .export()
 
     elif export_type == Export.REPORT:
@@ -60,13 +61,13 @@ def export_entries(export):
             .load_structure(report_structure)\
             .load_group_lables(queryset, show_groups)\
             .load_text_from_text_widgets(queryset, text_widget_ids)\
-            .add_entries(queryset)\
+            .add_entries(queryset, is_preview)\
             .export(pdf=pdf)
 
     elif export_type == Export.JSON:
         export_data = JsonExporter()\
             .load_exportables(exportables)\
-            .add_entries(queryset)\
+            .add_entries(queryset, is_preview)\
             .export()
 
     else:

--- a/apps/export/tasks/tasks_entries.py
+++ b/apps/export/tasks/tasks_entries.py
@@ -44,10 +44,10 @@ def export_entries(export):
 
     if export_type == Export.EXCEL:
         decoupled = filters.get('decoupled', True)
-        export_data = ExcelExporter(queryset, decoupled, project_id)\
+        export_data = ExcelExporter(queryset, decoupled, project_id, is_preview=is_preview)\
             .load_exportables(exportables, regions)\
-            .add_entries(queryset, is_preview)\
-            .export(is_preview)
+            .add_entries(queryset)\
+            .export()
 
     elif export_type == Export.REPORT:
         report_structure = filters.get('report_structure')
@@ -55,22 +55,24 @@ def export_entries(export):
         text_widget_ids = filters.get('text_widget_ids') or []
         show_groups = filters.get('show_groups')
         pdf = export.filters.get('pdf', False)
-        export_data = ReportExporter(exporting_widgets=exporting_widgets)\
+        export_data = ReportExporter(exporting_widgets=exporting_widgets, is_preview=is_preview)\
             .load_exportables(exportables, regions)\
             .load_levels(report_levels)\
             .load_structure(report_structure)\
             .load_group_lables(queryset, show_groups)\
             .load_text_from_text_widgets(queryset, text_widget_ids)\
-            .add_entries(queryset, is_preview)\
-            .export(is_preview, pdf=pdf)
+            .add_entries(queryset)\
+            .export(pdf=pdf)
 
     elif export_type == Export.JSON:
-        export_data = JsonExporter()\
+        export_data = JsonExporter(is_preview=is_preview)\
             .load_exportables(exportables)\
-            .add_entries(queryset, is_preview)\
-            .export(is_preview)
+            .add_entries(queryset)\
+            .export()
 
     else:
-        raise Exception('(Entries Export) Unkown Export Type Provided: {} for Export:'.format(export_type, export.id))
+        raise Exception(
+            '(Entries Export) Unkown Export Type Provided: {export_type} for Export: {export.id}'
+        )
 
     return export_data

--- a/apps/export/tasks/tasks_entries.py
+++ b/apps/export/tasks/tasks_entries.py
@@ -47,7 +47,7 @@ def export_entries(export):
         export_data = ExcelExporter(queryset, decoupled, project_id)\
             .load_exportables(exportables, regions)\
             .add_entries(queryset, is_preview)\
-            .export()
+            .export(is_preview)
 
     elif export_type == Export.REPORT:
         report_structure = filters.get('report_structure')
@@ -62,13 +62,13 @@ def export_entries(export):
             .load_group_lables(queryset, show_groups)\
             .load_text_from_text_widgets(queryset, text_widget_ids)\
             .add_entries(queryset, is_preview)\
-            .export(pdf=pdf)
+            .export(is_preview, pdf=pdf)
 
     elif export_type == Export.JSON:
         export_data = JsonExporter()\
             .load_exportables(exportables)\
             .add_entries(queryset, is_preview)\
-            .export()
+            .export(is_preview)
 
     else:
         raise Exception('(Entries Export) Unkown Export Type Provided: {} for Export:'.format(export_type, export.id))

--- a/apps/export/views.py
+++ b/apps/export/views.py
@@ -32,7 +32,10 @@ class ExportViewSet(viewsets.ModelViewSet):
     filterset_class = ExportFilterSet
 
     def get_queryset(self):
-        return Export.get_for(self.request.user)
+        qs = Export.get_for(self.request.user)
+        if self.action == 'list':
+            return qs.filter(is_preview=False)
+        return qs
 
     def destroy(self, request, *args, **kwargs):
         export = self.get_object()


### PR DESCRIPTION
Related to:
- Export: Prefix with `Preview-` all preview exports https://github.com/the-deep/server/issues/608
- Word Export: Limit the number of entries to 50 for preview https://github.com/the-deep/server/issues/607

Also removed preview exports from listing API. cc: @AdityaKhatri 