### PR TITLE
Allow entry filters with lead filters in lead/filters api; Filter leads and inclusion parameter during export

### DIFF
--- a/apps/lead/filter_set.py
+++ b/apps/lead/filter_set.py
@@ -1,4 +1,5 @@
 from django.db import models
+from django.core.exceptions import FieldError
 import django_filters
 
 from deep.filter_set import DjangoFilterCSVWidget
@@ -33,6 +34,10 @@ class LeadFilterSet(django_filters.FilterSet):
         (ASSESSMENT_EXISTS, 'Assessment Exists'),
         (ENTRIES_DO_NOT_EXIST, 'Entries do not exist'),
         (ASSESSMENT_DOES_NOT_EXIST, 'Assessment does not exist'),
+    )
+    EXCLUDE_EMPTY_FILTERED_ENTRIES = 'exclude_empty_filtered_entries'
+    FILTERED_ENTRIES_CHOICE = (
+        (EXCLUDE_EMPTY_FILTERED_ENTRIES, 'exclude empty filtered entries'),
     )
 
     search = django_filters.CharFilter(method='search_filter')
@@ -120,6 +125,11 @@ class LeadFilterSet(django_filters.FilterSet):
         method='authoring_organization_types_filter',
         widget=DjangoFilterCSVWidget,
         queryset=OrganizationType.objects.all(),
+    )
+    # used in export
+    custom_filters = django_filters.ChoiceFilter(
+        label='Filtered Exists Choice',
+        choices=FILTERED_ENTRIES_CHOICE, method='filtered_exists_filter',
     )
 
     class Meta:
@@ -220,6 +230,13 @@ class LeadFilterSet(django_filters.FilterSet):
                 )
             )
             return qs.filter(organization_types__in=[ot.id for ot in value]).distinct()
+        return qs
+
+    def filtered_exists_filter(self, qs, name, value):
+        if value == self.EXCLUDE_EMPTY_FILTERED_ENTRIES:
+            # NOTE: `filtered_entries_count` is annotated in LeadViewSet.filter, currently used for
+            # solely export list page
+            return qs.filter(filtered_entries_count__gte=1)
         return qs
 
 

--- a/apps/lead/filter_set.py
+++ b/apps/lead/filter_set.py
@@ -36,8 +36,10 @@ class LeadFilterSet(django_filters.FilterSet):
         (ASSESSMENT_DOES_NOT_EXIST, 'Assessment does not exist'),
     )
     EXCLUDE_EMPTY_FILTERED_ENTRIES = 'exclude_empty_filtered_entries'
+    EXCLUDE_EMPTY_VERIFIED_FILTERED_ENTRIES = 'exclude_empty_verified_filtered_entries'
     FILTERED_ENTRIES_CHOICE = (
         (EXCLUDE_EMPTY_FILTERED_ENTRIES, 'exclude empty filtered entries'),
+        (EXCLUDE_EMPTY_VERIFIED_FILTERED_ENTRIES , 'exclude empty verified filtered entries'),
     )
 
     search = django_filters.CharFilter(method='search_filter')
@@ -233,10 +235,11 @@ class LeadFilterSet(django_filters.FilterSet):
         return qs
 
     def filtered_exists_filter(self, qs, name, value):
+        # NOTE: check annotations at Lead.get_for
         if value == self.EXCLUDE_EMPTY_FILTERED_ENTRIES:
-            # NOTE: `filtered_entries_count` is annotated in LeadViewSet.filter, currently used for
-            # solely export list page
             return qs.filter(filtered_entries_count__gte=1)
+        elif value == self.EXCLUDE_EMPTY_VERIFIED_FILTERED_ENTRIES:
+            return qs.filter(verified_filtered_entries_count__gte=1)
         return qs
 
 

--- a/apps/lead/models.py
+++ b/apps/lead/models.py
@@ -224,10 +224,10 @@ class Lead(UserResource, ProjectEntityMixin):
             models.Q(view_all=view_perm_value)
         )
         # filter entries
-        original_filter = entries_filter_data = filters.get('entries_filter_data', {})
-        project = original_filter.pop('project', None)
+        entries_filter_data = filters.get('entries_filter_data', {})
+        original_filter = {**entries_filter_data}
+        original_filter.pop('project', None)
         entries_filter_data['from_subquery'] = True
-        entries_filter_data['project'] = project
 
         return qs.annotate(
             entries_count=models.Count('entry', distinct=True),

--- a/apps/lead/models.py
+++ b/apps/lead/models.py
@@ -239,7 +239,7 @@ class Lead(UserResource, ProjectEntityMixin):
                         count=models.Count('id')
                     ).values('count')[:1], output_field=models.IntegerField()
                 ), 0
-            ) if entries_filter_data else F('entries_count'),
+            ) if entries_filter_data else models.F('entries_count'),
             verified_filtered_entries_count=models.functions.Coalesce(
                 models.Subquery(
                     get_filtered_entries(user, entries_filter_data).filter(
@@ -249,7 +249,7 @@ class Lead(UserResource, ProjectEntityMixin):
                         count=models.Count('id')
                     ).values('count')[:1], output_field=models.IntegerField()
                 ), 0
-            ) if entries_filter_data else F('verified_entries_count'),
+            ) if entries_filter_data else models.F('verified_entries_count'),
         )
 
     def get_assignee(self):

--- a/apps/lead/models.py
+++ b/apps/lead/models.py
@@ -225,6 +225,7 @@ class Lead(UserResource, ProjectEntityMixin):
         )
         # filter entries
         entries_filter_data = filters.get('entries_filter_data', {})
+        entries_filter_data['from_subquery'] = True
 
         return qs.annotate(
             entries_count=models.Count('entry', distinct=True),

--- a/apps/lead/models.py
+++ b/apps/lead/models.py
@@ -254,12 +254,6 @@ class Lead(UserResource, ProjectEntityMixin):
             'assessments': Assessment.objects.filter(lead__project_id=project_id, lead__in=lead_ids).count(),
         }
 
-    def get_verified_entries_count(self):
-        # if annotated previously then return as is
-        if hasattr(self, 'verified_entries_count'):
-            return self.verified_entries_count
-        return self.entry_set.filter(verified=True).count()
-
 
 class LeadPreview(models.Model):
     STATUS_CLASSIFICATION_NONE = 'none'  # For leads which are not texts

--- a/apps/lead/serializers.py
+++ b/apps/lead/serializers.py
@@ -126,6 +126,9 @@ class LeadSerializer(
     """
     # annotated in lead.get_for
     no_of_entries = serializers.IntegerField(read_only=True)
+    verified_entries_count = serializers.IntegerField(read_only=True)
+    # annotated in LeadViewSet filter
+    filtered_entries_count = serializers.IntegerField(read_only=True)
     assessment_id = serializers.IntegerField(read_only=True)
 
     priority_display = serializers.CharField(source='get_priority_display', read_only=True)
@@ -176,8 +179,6 @@ class LeadSerializer(
     emm_entities = EMMEntitySerializer(many=True, required=False)
     # extra fields added from entryleadserializer
     confidentiality_display = serializers.CharField(source='get_confidentiality_display', read_only=True)
-    verified_entries_count = serializers.IntegerField(source='get_verified_entries_count',
-                                                      read_only=True)
 
     class Meta:
         model = Lead
@@ -185,7 +186,6 @@ class LeadSerializer(
         # Legacy Fields
         read_only_fields = ('author_raw', 'source_raw')
         write_only_on_create_fields = ['emm_triggers', 'emm_entities']
-
 
     def get_tabular_book(self, obj):
         file = obj.attachment

--- a/apps/lead/serializers.py
+++ b/apps/lead/serializers.py
@@ -125,10 +125,11 @@ class LeadSerializer(
     Lead Model Serializer
     """
     # annotated in lead.get_for
-    no_of_entries = serializers.IntegerField(read_only=True)
+    entries_count = serializers.IntegerField(read_only=True)
     verified_entries_count = serializers.IntegerField(read_only=True)
-    # annotated in LeadViewSet filter
     filtered_entries_count = serializers.IntegerField(read_only=True)
+    verified_filtered_entries_count = serializers.IntegerField(read_only=True)
+    
     assessment_id = serializers.IntegerField(read_only=True)
 
     priority_display = serializers.CharField(source='get_priority_display', read_only=True)

--- a/apps/lead/tests/test_apis.py
+++ b/apps/lead/tests/test_apis.py
@@ -268,7 +268,7 @@ class LeadTests(TestCase):
         response = self.client.get(url)
 
         r_data = response.json()
-        assert 'noOfEntries' in r_data["results"][0]
+        assert 'entriesCount' in r_data["results"][0]
 
     def test_create_lead_no_create_role(self, assignee=None):
         lead_count = Lead.objects.count()

--- a/apps/lead/tests/test_apis.py
+++ b/apps/lead/tests/test_apis.py
@@ -16,6 +16,12 @@ from organization.models import (
 from organization.serializers import SimpleOrganizationSerializer
 from lead.filter_set import LeadFilterSet
 from lead.serializers import SimpleLeadGroupSerializer
+from entry.models import (
+    Entry,
+    ProjectEntryLabel,
+    LeadEntryGroup,
+    EntryGroupLabel,
+)
 from lead.models import (
     Lead,
     LeadPreview,
@@ -1083,14 +1089,53 @@ class LeadTests(TestCase):
         response = self.client.post(url, post_data)
         assert response.json()['count'] == 0, 'There are not supposed to be leads with entries'
 
-        self.create(Entry, project=project, lead=lead1, verified=True)
-        self.create(Entry, project=project, lead=lead1, verified=False)
-        self.create(Entry, project=project, lead=lead2, verified=False)
+        entry1 = self.create(Entry, project=project, lead=lead1, verified=True,
+                             entry_type=Entry.EXCERPT)
+        entry2 = self.create(Entry, project=project, lead=lead2, verified=False,
+                             entry_type=Entry.IMAGE)
+        entry3 = self.create(Entry, project=project, lead=lead3, verified=False,
+                             entry_type=Entry.DATA_SERIES)
 
         post_data = {'custom_filters': 'exclude_empty_filtered_entries',
-                     'entries_filter': {'verified': True}}
+                     'entries_filter': [('verified', True)]}
         response = self.client.post(url, post_data)
         assert response.json()['count'] == 1
+        assert response.json()['results'][0]['filteredEntriesCount'] == 1, response.json()
+
+        post_data['entries_filter'] = []
+        post_data['entries_filter'].append(('entry_type', [Entry.EXCERPT, Entry.IMAGE]))
+        response = self.client.post(url, post_data)
+        self.assertEqual(response.json()['count'], 2, response.json())
+        assert response.json()['results'][0]['filteredEntriesCount'] == 1, response.json()
+
+        # filter by project_entry_labels
+        # Labels
+        label1 = self.create(ProjectEntryLabel, project=project, title='Label 1', order=1,
+                             color='#23f23a')
+        label2 = self.create(ProjectEntryLabel, project=project, title='Label 2', order=2,
+                             color='#23f23a')
+        label3 = self.create(ProjectEntryLabel, project=project, title='Label 3', order=3,
+                             color='#23f23a')
+
+        # Groups
+        group11 = self.create(LeadEntryGroup, lead=lead1, title='Group 1', order=1)
+        group12 = self.create(LeadEntryGroup, lead=lead1, title='Group 2', order=2)
+        group21 = self.create(LeadEntryGroup, lead=lead2, title='Group 2', order=2)
+
+        self.create(EntryGroupLabel, group=group11, label=label1, entry=entry1)
+        self.create(EntryGroupLabel, group=group12, label=label2, entry=entry1)
+        self.create(EntryGroupLabel, group=group21, label=label2, entry=entry2)
+
+        post_data['entries_filter'] = []
+        post_data['entries_filter'].append(('project_entry_labels', [label1.id]))
+        response = self.client.post(url, post_data)
+        self.assertEqual(response.json()['count'], 1, response.json())
+        assert response.json()['results'][0]['filteredEntriesCount'] == 1, response.json()
+
+        post_data['entries_filter'] = []
+        post_data['entries_filter'].append(('project_entry_labels', [label1.id, label2.id]))
+        response = self.client.post(url, post_data)
+        self.assertEqual(response.json()['count'], 2, response.json())
         assert response.json()['results'][0]['filteredEntriesCount'] == 1, response.json()
 
     def test_filtered_lead_list_with_verified_entries_count(self):

--- a/apps/lead/tests/test_apis.py
+++ b/apps/lead/tests/test_apis.py
@@ -1091,16 +1091,24 @@ class LeadTests(TestCase):
 
         entry1 = self.create(Entry, project=project, lead=lead1, verified=True,
                              entry_type=Entry.EXCERPT)
+        entry11 = self.create(Entry, project=project, lead=lead1, verified=True,
+                              entry_type=Entry.EXCERPT)
+        post_data = {'entries_filter': [('verified', True)]}
+        response = self.client.post(url, post_data)
+        assert response.json()['count'] == 3
+        assert set([each['filteredEntriesCount'] for each in response.json()['results']]) == set([0, 0, 2]),\
+            response.json()
+
         entry2 = self.create(Entry, project=project, lead=lead2, verified=False,
                              entry_type=Entry.IMAGE)
         entry3 = self.create(Entry, project=project, lead=lead3, verified=False,
                              entry_type=Entry.DATA_SERIES)
-
         post_data = {'custom_filters': 'exclude_empty_filtered_entries',
                      'entries_filter': [('verified', True)]}
         response = self.client.post(url, post_data)
         assert response.json()['count'] == 1
-        assert response.json()['results'][0]['filteredEntriesCount'] == 1, response.json()
+        assert response.data['results'][0]['id'] == lead1.id, response.data
+        assert response.json()['results'][0]['filteredEntriesCount'] == 2, response.json()
 
         post_data['entries_filter'] = []
         post_data['entries_filter'].append(('entry_type', [Entry.EXCERPT, Entry.IMAGE]))

--- a/apps/lead/views.py
+++ b/apps/lead/views.py
@@ -149,7 +149,9 @@ class LeadViewSet(viewsets.ModelViewSet):
 
     def get_queryset(self):
         filters = dict()
-        filters['entries_filter_data'] = self.request.data.pop('entries_filter', {})
+        filters['entries_filter_data'] = {
+            f[0]: f[1] for f in self.request.data.pop('entries_filter', [])
+        }
         leads = Lead.get_for(self.request.user, filters)
         lead_id = self.request.GET.get('similar')
         if lead_id:

--- a/apps/lead/views.py
+++ b/apps/lead/views.py
@@ -8,6 +8,7 @@ from django.contrib.auth.models import User
 from django.contrib.postgres.search import TrigramSimilarity
 from django.db import models, transaction
 
+from deep import compiler
 from rest_framework.decorators import action
 from rest_framework import (
     serializers,
@@ -152,7 +153,9 @@ class LeadViewSet(viewsets.ModelViewSet):
         filters['entries_filter_data'] = {
             f[0]: f[1] for f in self.request.data.pop('entries_filter', [])
         }
+        filters['entries_filter_data']['project'] = self.request.data.get('project', [None])[0]
         leads = Lead.get_for(self.request.user, filters)
+
         lead_id = self.request.GET.get('similar')
         if lead_id:
             similar_lead = Lead.objects.get(id=lead_id)

--- a/apps/lead/views.py
+++ b/apps/lead/views.py
@@ -153,7 +153,12 @@ class LeadViewSet(viewsets.ModelViewSet):
         filters['entries_filter_data'] = {
             f[0]: f[1] for f in self.request.data.pop('entries_filter', [])
         }
-        filters['entries_filter_data']['project'] = self.request.data.get('project', [None])[0]
+        if self.request.data.get('project'):
+            project_id = self.request.data['project']
+            if isinstance(project_id, list) and len(project_id) > 0:
+                filters['entries_filter_data']['project'] = project_id[0]
+            else:
+                filters['entries_filter_data']['project'] = project_id
         leads = Lead.get_for(self.request.user, filters)
 
         lead_id = self.request.GET.get('similar')

--- a/apps/lead/views.py
+++ b/apps/lead/views.py
@@ -8,7 +8,7 @@ from django.contrib.auth.models import User
 from django.contrib.postgres.search import TrigramSimilarity
 from django.db import models, transaction
 
-from deep import compiler
+from deep import compiler  # noqa: F401
 from rest_framework.decorators import action
 from rest_framework import (
     serializers,

--- a/apps/lead/views.py
+++ b/apps/lead/views.py
@@ -25,7 +25,6 @@ import django_filters
 
 from deep.permissions import ModifyPermission, CreateLeadPermission, DeleteLeadPermission
 from deep.paginations import AutocompleteSetPagination
-from entry.filter_set import get_filtered_entries
 
 from lead.filter_set import (
     LeadGroupFilterSet,
@@ -149,7 +148,9 @@ class LeadViewSet(viewsets.ModelViewSet):
         )
 
     def get_queryset(self):
-        leads = Lead.get_for(self.request.user)
+        filters = dict()
+        filters['entries_filter_data'] = self.request.data.pop('entries_filter', {})
+        leads = Lead.get_for(self.request.user, filters)
         lead_id = self.request.GET.get('similar')
         if lead_id:
             similar_lead = Lead.objects.get(id=lead_id)
@@ -211,22 +212,9 @@ class LeadViewSet(viewsets.ModelViewSet):
     )
     def leads_filter(self, request, version=None):
         raw_filter_data = request.data
-        raw_entries_filter_data = raw_filter_data.pop('entries_filter', {})
         filter_data = self._get_processed_filter_data(raw_filter_data)
-        entries_filter_data = raw_entries_filter_data
 
         queryset = self.get_queryset()
-        queryset = queryset.annotate(
-            filtered_entries_count=models.functions.Coalesce(
-                models.Subquery(
-                    get_filtered_entries(self.request.user, entries_filter_data).filter(
-                        lead=models.OuterRef('pk')
-                    ).values('lead').order_by().annotate(
-                        count=models.Count('id')
-                    ).values('count')[:1], output_field=models.IntegerField()
-                ), 0
-            )
-        )
         qs = LeadFilterSet(data=filter_data, queryset=queryset).qs
         page = self.paginate_queryset(qs)
 

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,2 @@
+github_checks:
+  annotations: false

--- a/deep/compiler.py
+++ b/deep/compiler.py
@@ -5,8 +5,8 @@ from django.utils.hashable import make_hashable
 class CustomSQLCompiler:
     def get_group_by(self, select, order_by):
         """
-        Original SQLCompiler.get_group_by produces type error when with tuple(params) when checking
-        with seen in the last if statement. This is fixed in the newer version (2021-01-19).
+        Original SQLCompiler.get_group_by produces type error with tuple(params) when checking
+        with seen in the last if statement. This is fixed in the newer version (checking on 3.0).
         """
         if self.query.group_by is None:
             return []

--- a/deep/compiler.py
+++ b/deep/compiler.py
@@ -1,0 +1,53 @@
+from django.db.models.sql.compiler import SQLCompiler
+from django.utils.hashable import make_hashable
+
+
+class CustomSQLCompiler:
+    def get_group_by(self, select, order_by):
+        """
+        Original SQLCompiler.get_group_by produces type error when with tuple(params) when checking
+        with seen in the last if statement. This is fixed in the newer version (2021-01-19).
+        """
+        if self.query.group_by is None:
+            return []
+        expressions = []
+        if self.query.group_by is not True:
+            # If the group by is set to a list (by .values() call most likely),
+            # then we need to add everything in it to the GROUP BY clause.
+            # Backwards compatibility hack for setting query.group_by. Remove
+            # when  we have public API way of forcing the GROUP BY clause.
+            # Converts string references to expressions.
+            for expr in self.query.group_by:
+                if not hasattr(expr, 'as_sql'):
+                    expressions.append(self.query.resolve_ref(expr))
+                else:
+                    expressions.append(expr)
+        # Note that even if the group_by is set, it is only the minimal
+        # set to group by. So, we need to add cols in select, order_by, and
+        # having into the select in any case.
+        for expr, _, _ in select:
+            cols = expr.get_group_by_cols()
+            for col in cols:
+                expressions.append(col)
+        for expr, (sql, params, is_ref) in order_by:
+            # Skip References to the select clause, as all expressions in the
+            # select clause are already part of the group by.
+            if not expr.contains_aggregate and not is_ref:
+                expressions.extend(expr.get_source_expressions())
+        having_group_by = self.having.get_group_by_cols() if self.having else ()
+        for expr in having_group_by:
+            expressions.append(expr)
+        result = []
+        seen = set()
+        expressions = self.collapse_group_by(expressions, having_group_by)
+
+        for expr in expressions:
+            sql, params = self.compile(expr)
+            params_hash = make_hashable(params)
+            if (sql, params_hash) not in seen:
+                result.append((sql, params))
+                seen.add((sql, params_hash))
+        return result
+
+
+SQLCompiler.get_group_by = CustomSQLCompiler.get_group_by


### PR DESCRIPTION
Add two more filter params to existing `lead filter api`

- entries_filter: json = this expects the same filters as Entry list filter
- custom_filters: choices [ `exclude_empty_filtered_entries`, `exclude_empty_verified_filtered_entries` ]
    - if `exclude_empty_filtered_entries` will not return leads with zero filtered entries
    - if `exclude_empty_verified_filtered_entries` will not return leads with zero filtered AND verified entries

filtered entries count can be retrieved from `filteredEntriesCount` and similarly `verifiedFilteredEntriesCount`.

...

Previously exports only required `lead = [...ids]` param. Now it requires following new params along with existing `lead`.

1. `include_leads`: Boolean = it states whether to include or exclude the `lead` from export.
2. `lead_filters`= Same as lead filter api, along with a nested `entries_filters` key to filter the entries.

~~Depends on~~ #622 rebased and closed.