### PR TITLE
Fix ProjectMembership Api

### DIFF
--- a/apps/project/permissions.py
+++ b/apps/project/permissions.py
@@ -109,7 +109,6 @@ class MembershipModifyPermission(permissions.BasePermission):
             member=request.user
         ).first()
         user_role = user and user.role
-
         if not user_role or user_role.level > obj.role.level:
             return False
 

--- a/apps/project/serializers.py
+++ b/apps/project/serializers.py
@@ -325,6 +325,14 @@ class ProjectSerializer(RemoveNullFieldsMixin,
         model = Project
         exclude = ('members', )
 
+    def to_representation(self, data):
+        result = super().to_representation(data)
+        if not result['is_private'] and self.context['request'].user.id in [e['member'] for e in result['memberships']]:
+            pass
+        else:
+            result['memberships'] = []
+        return result
+
     def create(self, validated_data):
         member = self.context['request'].user
         is_private = validated_data.get('is_private', False)
@@ -457,6 +465,8 @@ class ProjectSerializer(RemoveNullFieldsMixin,
                 'Invalid analysis framework: {}'.format(analysis_framework.id))
         return analysis_framework
 
+    """def to_representation(self, data):
+        print("data", data)"""
 
 class ProjectStatSerializer(ProjectSerializer):
     number_of_leads = serializers.IntegerField(read_only=True)

--- a/apps/project/serializers.py
+++ b/apps/project/serializers.py
@@ -286,11 +286,6 @@ class ProjectUsergroupMembershipSerializer(RemoveNullFieldsMixin,
 
 class ProjectSerializer(RemoveNullFieldsMixin,
                         DynamicFieldsMixin, UserResourceSerializer):
-    memberships = ProjectMembershipSerializer(
-        source='projectmembership_set',
-        many=True,
-        read_only=True,
-    )
 
     organizations = ProjectOrganizationSerializer(
         source='projectorganization_set',
@@ -324,14 +319,6 @@ class ProjectSerializer(RemoveNullFieldsMixin,
     class Meta:
         model = Project
         exclude = ('members', )
-
-    def to_representation(self, data):
-        result = super().to_representation(data)
-        if not result['is_private'] and self.context['request'].user.id in [e['member'] for e in result['memberships']]:
-            pass
-        else:
-            result['memberships'] = []
-        return result
 
     def create(self, validated_data):
         member = self.context['request'].user
@@ -465,8 +452,14 @@ class ProjectSerializer(RemoveNullFieldsMixin,
                 'Invalid analysis framework: {}'.format(analysis_framework.id))
         return analysis_framework
 
-    """def to_representation(self, data):
-        print("data", data)"""
+
+class ProjectMemberViewSerializer(ProjectSerializer):
+    memberships = ProjectMembershipSerializer(
+        source='projectmembership_set',
+        many=True,
+        read_only=True,
+    )
+
 
 class ProjectStatSerializer(ProjectSerializer):
     number_of_leads = serializers.IntegerField(read_only=True)

--- a/apps/project/views.py
+++ b/apps/project/views.py
@@ -480,9 +480,12 @@ class ProjectViewSet(viewsets.ModelViewSet):
             models.Q(projectmembership__project=project) |
             models.Q(usergroup__projectusergroupmembership__project=project)
         ).distinct()
-        self.page = self.paginate_queryset(members)
-        serializer = self.get_serializer(self.page, many=True)
-        return self.get_paginated_response(serializer.data)
+        if members.filter(id=request.user.id).exists():
+            self.page = self.paginate_queryset(members)
+            serializer = self.get_serializer(self.page, many=True)
+            return self.get_paginated_response(serializer.data)
+        else:
+            return response.Response('Forbidden Acess', status=403)
 
     """
     Project Lead-Groups

--- a/deep/permissions.py
+++ b/deep/permissions.py
@@ -161,10 +161,15 @@ class IsProjectMember(permissions.BasePermission):
         lead_id = view.kwargs.get('lead_id')
         entry_id = view.kwargs.get('entry_id')
 
-        if project_id and Project.get_for_member(request.user).filter(id=project_id).exists():
-            return True
-        elif lead_id and Lead.get_for(request.user).filter(id=lead_id).exists():
-            return True
-        elif entry_id and Entry.get_for(request.user).filter(id=entry_id).exists():
-            return True
-        return False
+        if project_id:
+            return Project.get_for_member(request.user).filter(id=project_id).exists()
+        elif lead_id:
+            return Lead.get_for(request.user).filter(id=lead_id).exists()
+        elif entry_id:
+            return Entry.get_for(request.user).filter(id=entry_id).exists()
+        return True
+
+    def has_object_permission(self, request, view, obj):
+        if type(obj) == Project:
+            return obj.members.filter(id=request.user.id).exists()
+        return True


### PR DESCRIPTION

   1.Only project members can see project memberships of that project
    2.Only project admins can add users of that project
    3.Only project admins can modify users of that project
