### PR TITLE
Add role_title and addedby_username in project memberships and usergroup api

### DIFF
--- a/apps/project/serializers.py
+++ b/apps/project/serializers.py
@@ -128,6 +128,7 @@ class ProjectMembershipSerializer(RemoveNullFieldsMixin,
         read_only=True,
         many=True,
     )
+    role_title = serializers.CharField(source='role.title', read_only=True)
 
     class Meta:
         model = ProjectMembership
@@ -446,6 +447,8 @@ class ProjectJoinRequestSerializer(RemoveNullFieldsMixin,
 
 class ProjectUserGroupSerializer(serializers.ModelSerializer):
     title = serializers.CharField(source='usergroup.title', read_only=True)
+    role_title = serializers.CharField(source='role.title', read_only=True)
+    added_by_name = serializers.CharField(source='added_by.profile.get_display_name', read_only=True)
 
     class Meta:
         model = ProjectUserGroupMembership

--- a/apps/project/serializers.py
+++ b/apps/project/serializers.py
@@ -148,17 +148,14 @@ class ProjectMembershipSerializer(RemoveNullFieldsMixin,
             raise serializers.ValidationError('Invalid project')
         return project
 
+    def project_member_validation(self, project, member):
+        if ProjectMembership.objects.filter(project=project).filter(member=member).exists():
+            raise serializers.ValidationError({'member': 'Member already exist'})
+
     def validate(self, data):
         data['project_id'] = int(self.context['view'].kwargs['project_id'])
-        # get the members of the project
-        members = ProjectMembership.objects.filter(
-            project=data['project_id']
-        ).values('member')
         member = data.get('member')
-        if member:
-            member = member.id
-        if member in [mem['member'] for mem in members]:
-            raise serializers.ValidationError({'member': 'Member already exist'})
+        self.project_member_validation(data['project_id'], member)
         role = data.get('role')
         if not role:
             return data

--- a/apps/project/serializers.py
+++ b/apps/project/serializers.py
@@ -128,12 +128,12 @@ class ProjectMembershipSerializer(RemoveNullFieldsMixin,
         read_only=True,
         many=True,
     )
-    role_title = serializers.CharField(source='role.title', read_only=True)
+    role_details = SimpleProjectRoleSerializer(source='role', read_only=True)
 
     class Meta:
         model = ProjectMembership
         fields = '__all__'
-        read_only_fields = ('project', )
+        read_only_fields = ('project',)
 
     def get_member_status(self, membership):
         if ProjectRole.get_admin_roles().filter(
@@ -451,7 +451,7 @@ class ProjectJoinRequestSerializer(RemoveNullFieldsMixin,
 
 class ProjectUserGroupSerializer(serializers.ModelSerializer):
     title = serializers.CharField(source='usergroup.title', read_only=True)
-    role_title = serializers.CharField(source='role.title', read_only=True)
+    role_details = SimpleProjectRoleSerializer(source='role', read_only=True)
     added_by_name = serializers.CharField(source='added_by.profile.get_display_name', read_only=True)
 
     class Meta:

--- a/apps/project/tests/test_apis.py
+++ b/apps/project/tests/test_apis.py
@@ -495,7 +495,7 @@ class ProjectApiTest(TestCase):
             # -1 because usergroup admin and project admin is common
             final_member_count
         )
-        self.assertEqual(response.data['role_title'], self.normal_role.title)
+        self.assertEqual(response.data['role_details']['title'], self.normal_role.title)
         self.assertEqual(response.data['project'], project.id)
 
     def test_update_project_remove_ug(self):
@@ -717,7 +717,7 @@ class ProjectApiTest(TestCase):
         self.assertEqual(response.data['role'], data['role'])
         self.assertEqual(response.data['member'], data['member'])
         self.assertEqual(response.data['project'], project.id)
-        self.assertEqual(response.data['role_title'], self.normal_role.title)
+        self.assertEqual(response.data['role_details']['title'], self.normal_role.title)
 
     def test_add_member_unexistent_role(self):
         project = self.create(Project, role=self.admin_role)

--- a/apps/project/tests/test_apis.py
+++ b/apps/project/tests/test_apis.py
@@ -477,9 +477,8 @@ class ProjectApiTest(TestCase):
         memberships = ProjectMembership.objects.filter(project=project)
         initial_member_count = memberships.count()
 
-        url = '/api/v1/project-usergroups/'
+        url = f'/api/v1/projects/{project.id}/project-usergroups/'
         data = {
-            'project': project.id,
             'usergroup': self.ug1.id,
             'role': self.normal_role.id
         }
@@ -497,6 +496,7 @@ class ProjectApiTest(TestCase):
             final_member_count
         )
         self.assertEqual(response.data['role_title'], self.normal_role.title)
+        self.assertEqual(response.data['project'], project.id)
 
     def test_update_project_remove_ug(self):
         project = self.create(
@@ -520,7 +520,7 @@ class ProjectApiTest(TestCase):
         ).count()
 
         # We keep just ug1, and remove ug2
-        url = '/api/v1/project-usergroups/{}/'.format(project_ug2.id)
+        url = f'/api/v1/projects/{project.id}/project-usergroups/{project_ug2.id}/'
 
         self.authenticate()
         response = self.client.delete(url)
@@ -704,10 +704,9 @@ class ProjectApiTest(TestCase):
         project = self.create(Project, role=self.admin_role)
         test_user = self.create(User)
 
-        url = '/api/v1/project-memberships/'
+        url = f'/api/v1/projects/{project.id}/project-memberships/'
         data = {
             'member': test_user.pk,
-            'project': project.pk,
             'role': self.normal_role.id,
         }
 
@@ -717,17 +716,16 @@ class ProjectApiTest(TestCase):
 
         self.assertEqual(response.data['role'], data['role'])
         self.assertEqual(response.data['member'], data['member'])
-        self.assertEqual(response.data['project'], data['project'])
+        self.assertEqual(response.data['project'], project.id)
         self.assertEqual(response.data['role_title'], self.normal_role.title)
 
     def test_add_member_unexistent_role(self):
         project = self.create(Project, role=self.admin_role)
         test_user = self.create(User)
 
-        url = '/api/v1/project-memberships/'
+        url = f'/api/v1/projects/{project.id}/project-memberships/'
         data = {
             'member': test_user.pk,
-            'project': project.pk,
             'role': 9999
         }
 
@@ -741,16 +739,16 @@ class ProjectApiTest(TestCase):
         test_user = self.create(User)
         project.add_member(test_user)
 
-        url = '/api/v1/project-memberships/'
+        url = f'/api/v1/projects/{project.id}/project-memberships/'
         data = {
-            'member': test_user.pk,
-            'project': project.pk,
+            'member': test_user.pk
         }
 
         self.authenticate()
         response = self.client.post(url, data)
         self.assert_400(response)
         assert 'errors' in response.data
+        assert 'member' in response.data['errors']
 
     def test_project_membership_edit_normal_role(self):
         # user try to update member where he/she isnot the admin in the project
@@ -760,7 +758,7 @@ class ProjectApiTest(TestCase):
         data = {
             'role': self.admin_role.id,
         }
-        url = '/api/v1/project-memberships/{}/'.format(m1.id)
+        url = f'/api/v1/projects/{project.id}/project-memberships/{m1.id}/'
         self.authenticate()  # authenticate with normal_role
         response = self.client.patch(url, data)
         self.assert_403(response)
@@ -772,7 +770,7 @@ class ProjectApiTest(TestCase):
         data = {
             'role': self.admin_role.id
         }
-        url = '/api/v1/project-memberships/{}/'.format(m1.id)
+        url = f'/api/v1/projects/{project.id}/project-memberships/{m1.id}/'
         self.authenticate()  # authenticate with admin_role
         response = self.client.patch(url, data)
         self.assert_200(response)
@@ -785,10 +783,9 @@ class ProjectApiTest(TestCase):
         project.add_member(test_user2, role=self.normal_role)
         data = {
             'member': test_user1.id,
-            'project': project.id,
             'role': self.admin_role.id
         }
-        url = '/api/v1/project-memberships/'
+        url = f'/api/v1/projects/{project.id}/project-memberships/'
         self.authenticate(test_user2)  # test_user2 has normal_role in project
         response = self.client.post(url, data)
         self.assert_400(response)
@@ -1054,8 +1051,8 @@ class ProjectApiTest(TestCase):
         m1 = project.add_member(test_user1, role=self.normal_role)
         m2 = project.add_member(test_user2, role=self.admin_role)
 
-        url1 = '/api/v1/project-memberships/{}/'.format(m1.id)
-        url2 = '/api/v1/project-memberships/{}/'.format(m2.id)
+        url1 = f'/api/v1/projects/{project.id}/project-memberships/{m1.id}/'
+        url2 = f'/api/v1/projects/{project.id}/project-memberships/{m2.id}/'
 
         # Initial condition: We are Admin
         self.authenticate()

--- a/apps/project/tests/test_apis.py
+++ b/apps/project/tests/test_apis.py
@@ -474,7 +474,6 @@ class ProjectApiTest(TestCase):
             title='TestProject',
             role=self.admin_role
         )
-
         memberships = ProjectMembership.objects.filter(project=project)
         initial_member_count = memberships.count()
 
@@ -482,6 +481,7 @@ class ProjectApiTest(TestCase):
         data = {
             'project': project.id,
             'usergroup': self.ug1.id,
+            'role': self.normal_role.id
         }
 
         self.authenticate()
@@ -496,6 +496,7 @@ class ProjectApiTest(TestCase):
             # -1 because usergroup admin and project admin is common
             final_member_count
         )
+        self.assertEqual(response.data['role_title'], self.normal_role.title)
 
     def test_update_project_remove_ug(self):
         project = self.create(
@@ -717,6 +718,7 @@ class ProjectApiTest(TestCase):
         self.assertEqual(response.data['role'], data['role'])
         self.assertEqual(response.data['member'], data['member'])
         self.assertEqual(response.data['project'], data['project'])
+        self.assertEqual(response.data['role_title'], self.normal_role.title)
 
     def test_add_member_unexistent_role(self):
         project = self.create(Project, role=self.admin_role)

--- a/apps/project/views.py
+++ b/apps/project/views.py
@@ -793,7 +793,9 @@ class ProjectMembershipViewSet(viewsets.ModelViewSet):
         )
 
     def get_queryset(self):
-        return ProjectMembership.get_for(self.request.user).filter(project=self.kwargs['project_id'])
+        return ProjectMembership.get_for(self.request.user).filter(project=self.kwargs['project_id']).select_related(
+            'role'
+        )
 
 
 class ProjectOptionsView(views.APIView):
@@ -929,4 +931,6 @@ class ProjectUserGroupViewSet(viewsets.ModelViewSet):
     filterset_class = ProjectUserGroupMembershipFilterSet
 
     def get_queryset(self):
-        return ProjectUserGroupMembership.objects.filter(project=self.kwargs['project_id'])
+        return ProjectUserGroupMembership.objects.filter(project=self.kwargs['project_id']).select_related(
+            'role'
+        )

--- a/apps/project/views.py
+++ b/apps/project/views.py
@@ -793,7 +793,7 @@ class ProjectMembershipViewSet(viewsets.ModelViewSet):
         )
 
     def get_queryset(self):
-        return ProjectMembership.get_for(self.request.user)
+        return ProjectMembership.get_for(self.request.user).filter(project=self.kwargs['project_id'])
 
 
 class ProjectOptionsView(views.APIView):
@@ -927,3 +927,6 @@ class ProjectUserGroupViewSet(viewsets.ModelViewSet):
                        filters.SearchFilter, filters.OrderingFilter)
     queryset = ProjectUserGroupMembership.objects.all()
     filterset_class = ProjectUserGroupMembershipFilterSet
+
+    def get_queryset(self):
+        return ProjectUserGroupMembership.objects.filter(project=self.kwargs['project_id'])

--- a/deep/urls.py
+++ b/deep/urls.py
@@ -238,9 +238,9 @@ router.register(r'projects-stat', ProjectStatViewSet,
                 basename='project-stat')
 router.register(r'project-roles', ProjectRoleViewSet,
                 basename='project_role')
-router.register(r'project-memberships', ProjectMembershipViewSet,
+router.register(r'projects/(?P<project_id>\d+)/project-memberships', ProjectMembershipViewSet,
                 basename='project_membership')
-router.register(r'project-usergroups', ProjectUserGroupViewSet,
+router.register(r'projects/(?P<project_id>\d+)/project-usergroups', ProjectUserGroupViewSet,
                 basename='project_usergroup')
 
 # Geo routers


### PR DESCRIPTION
Changed API:
- for project-memberships from `/api/v1/project-memberships` to `/api/v1/projects/{project.id}/project-memberships/`
- for project-usergroups from `/api/v1/project-usergroups` to `/api/v1/projects/{project.id}/project-usergroups/`

CC: @samshara  @subinasr 