### PR TITLE
Add project_status in project-options viewset

### DIFF
--- a/apps/project/tests/test_apis.py
+++ b/apps/project/tests/test_apis.py
@@ -2,6 +2,7 @@ import uuid
 
 from dateutil.relativedelta import relativedelta
 from django.utils import timezone
+from django.utils.hashable import make_hashable
 
 from user.models import (
     User,
@@ -798,16 +799,18 @@ class ProjectApiTest(TestCase):
         self.assert_200(response)
 
     def test_project_status_in_project_options(self):
+        choices = dict(make_hashable(Project.STATUS_CHOICES))
+
         url = '/api/v1/project-options/'
 
         self.authenticate()
         response = self.client.get(url)
         self.assert_200(response)
         self.assertIn('project_status', response.data)
-        self.assertEqual(response.data['project_status'][0]['key'], 'active')
-        self.assertEqual(response.data['project_status'][0]['value'], 'Active')
-        self.assertEqual(response.data['project_status'][1]['key'], 'inactive')
-        self.assertEqual(response.data['project_status'][1]['value'], 'Inactive')
+        self.assertEqual(response.data['project_status'][0]['key'], Project.ACTIVE)
+        self.assertEqual(response.data['project_status'][0]['value'], choices[Project.ACTIVE])
+        self.assertEqual(response.data['project_status'][1]['key'], Project.INACTIVE)
+        self.assertEqual(response.data['project_status'][1]['value'], choices[Project.INACTIVE])
 
     def test_join_request(self):
         project = self.create(Project, role=self.admin_role)

--- a/apps/project/tests/test_apis.py
+++ b/apps/project/tests/test_apis.py
@@ -797,6 +797,18 @@ class ProjectApiTest(TestCase):
         response = self.client.get(url)
         self.assert_200(response)
 
+    def test_project_status_in_project_options(self):
+        url = '/api/v1/project-options/'
+
+        self.authenticate()
+        response = self.client.get(url)
+        self.assert_200(response)
+        self.assertIn('project_status', response.data)
+        self.assertEqual(response.data['project_status'][0]['key'], 'active')
+        self.assertEqual(response.data['project_status'][0]['value'], 'Active')
+        self.assertEqual(response.data['project_status'][1]['key'], 'inactive')
+        self.assertEqual(response.data['project_status'][1]['value'], 'Inactive')
+
     def test_join_request(self):
         project = self.create(Project, role=self.admin_role)
         test_user = self.create(User)

--- a/apps/project/views.py
+++ b/apps/project/views.py
@@ -868,9 +868,9 @@ class ProjectOptionsView(views.APIView):
             ]
         options['project_status'] = [
             {
-                'key': status[0],
-                'value': status[1]
-            } for status in Project.STATUS_CHOICES
+                'key': value,
+                'value': label
+            } for value, label in Project.STATUS_CHOICES
         ]
         return response.Response(options)
 

--- a/apps/project/views.py
+++ b/apps/project/views.py
@@ -866,7 +866,12 @@ class ProjectOptionsView(views.APIView):
                 {'key': 'my_projects', 'value': 'My projects'},
                 {'key': 'not_my_projects', 'value': 'Not my projects'}
             ]
-
+        options['project_status'] = [
+            {
+                'key': status[0],
+                'value': status[1]
+            } for status in Project.STATUS_CHOICES
+        ]
         return response.Response(options)
 
 


### PR DESCRIPTION
fixes:
- #725 Project Options: Send options for project status in `api/v1/project-options/`