### PR TITLE
Restrict same usergroup create multiple times in a project

### DIFF
--- a/apps/project/serializers.py
+++ b/apps/project/serializers.py
@@ -459,19 +459,13 @@ class ProjectUserGroupSerializer(serializers.ModelSerializer):
         fields = '__all__'
         read_only_fields = ('project',)
 
-    def validate_project_usergroup(self, project, usergroup):
-        if ProjectUserGroupMembership.objects.filter(project=project, usergroup=usergroup).exists():
-            raise serializers.ValidationError({'usergroup': 'Usergroup already exist in the project'})
-
     def validate(self, data):
         data['project_id'] = int(self.context['view'].kwargs['project_id'])
         usergroup = data.get('usergroup')
-        usergroup = self.validate_project_usergroup(data['project_id'], usergroup)
+        if usergroup and ProjectUserGroupMembership.objects.filter(project=data['project_id'],
+                                                                   usergroup=usergroup).exists():
+            raise serializers.ValidationError({'usergroup': 'Usergroup already exist in the project'})
         return data
-
-    def create(self, validated_data):
-        instance, _ = ProjectUserGroupMembership.objects.get_or_create(**validated_data)
-        return instance
 
 
 class ProjectRecentActivitySerializer(serializers.Serializer):

--- a/apps/project/serializers.py
+++ b/apps/project/serializers.py
@@ -459,9 +459,19 @@ class ProjectUserGroupSerializer(serializers.ModelSerializer):
         fields = '__all__'
         read_only_fields = ('project',)
 
+    def validate_project_usergroup(self, project, usergroup):
+        if ProjectUserGroupMembership.objects.filter(project=project, usergroup=usergroup).exists():
+            raise serializers.ValidationError({'usergroup': 'Usergroup already exist in the project'})
+
     def validate(self, data):
         data['project_id'] = int(self.context['view'].kwargs['project_id'])
+        usergroup = data.get('usergroup')
+        usergroup = self.validate_project_usergroup(data['project_id'], usergroup)
         return data
+
+    def create(self, validated_data):
+        instance, _ = ProjectUserGroupMembership.objects.get_or_create(**validated_data)
+        return instance
 
 
 class ProjectRecentActivitySerializer(serializers.Serializer):

--- a/apps/project/tests/test_apis.py
+++ b/apps/project/tests/test_apis.py
@@ -539,6 +539,31 @@ class ProjectApiTest(TestCase):
             final_member_count
         )
 
+    def test_duplicate_usergroup_add_in_project(self):
+        project = self.create(
+            Project,
+            title='For test',
+            user_groups=[],
+            role=self.admin_role
+        )
+        # add usergroup to the project
+        ProjectUserGroupMembership.objects.create(
+            usergroup=self.ug1,
+            project=project
+        )
+
+        # now try to create same usergroup from api level
+        data = {
+            'usergroup': self.ug1.id,
+            'role': self.normal_role.id
+        }
+        url = f'/api/v1/projects/{project.id}/project-usergroups/'
+        self.authenticate()
+        response = self.client.post(url, data)
+        self.assert_400(response)
+        assert 'errors' in response.data
+        assert 'usergroup' in response.data['errors']
+
     def test_add_user_to_usergroup(self):
         project = self.create(
             Project,


### PR DESCRIPTION
Fixes:
- #740 New Project Flow: Handle error while adding same user-group twice in a project