### PR TITLE
Skip xml escape logic for report text.

### DIFF
--- a/apps/export/formats/docx.py
+++ b/apps/export/formats/docx.py
@@ -1,4 +1,12 @@
+import docx
+import requests
+import io
+import re
+import tempfile
+import base64
+import logging
 from uuid import uuid4
+
 
 from docx.enum.dml import MSO_THEME_COLOR_INDEX
 from docx.oxml import OxmlElement, oxml_parser
@@ -7,18 +15,14 @@ from docx.shared import Pt, RGBColor
 
 from PIL import Image
 
-import docx
-import requests
-import io
-import re
-import tempfile
-import base64
-import logging
-
-from utils.common import get_valid_xml_string as xstr
+from utils.common import get_valid_xml_string
 
 
 logger = logging.getLogger(__name__)
+
+
+def xstr(text):
+    return get_valid_xml_string(text, escape=False)
 
 
 def _write_file(r, fp):
@@ -168,7 +172,7 @@ class Paragraph:
         r_pr = docx.oxml.shared.OxmlElement('w:rPr')
 
         new_run.append(r_pr)
-        new_run.text = xstr(text)
+        new_run.text = get_valid_xml_string(text)
 
         hyperlink.append(new_run)
         self.ref._p.append(hyperlink)


### PR DESCRIPTION
https://github.com/the-deep/client/issues/1496

Before:
![image](https://user-images.githubusercontent.com/7059255/116701207-5a275a00-a9e7-11eb-9bbb-dd6251518713.png)


After:
![image](https://user-images.githubusercontent.com/7059255/116701196-57c50000-a9e7-11eb-91ee-146189ea4911.png)
