### PR TITLE
Add more informations in analysis summary

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,7 @@ ARG ORCA_VERSION=1.2.1
 RUN apt-get update -y && apt-get install -y \
         # Basic Packages
         git \
+        iproute2 \
         locales \
         vim \
         curl \

--- a/apps/analysis/models.py
+++ b/apps/analysis/models.py
@@ -1,8 +1,10 @@
 import copy
 
 from django.db import models
-from django.utils.translation import gettext_lazy as _
 from django_enumfield import enum
+from django.db.models.functions import JSONObject
+from django.db import connection as django_db_connection
+from django.utils.translation import gettext_lazy as _
 
 from user.models import User
 from project.models import Project
@@ -32,52 +34,137 @@ class Analysis(UserResource):
         analysis_cloned.save()
         return analysis_cloned
 
+    @classmethod
+    def get_analyzed_sources(cls, analysis_list):
+        # NOTE: Used by AnalysisSummarySerializer, AnalysisViewSet.get_summary
+        analysis_ids = [analysis.id for analysis in analysis_list]
+
+        leads_dragged = AnalyticalStatement.objects\
+            .filter(analysis_pillar__analysis__in=analysis_ids)\
+            .order_by().values('analysis_pillar__analysis', 'entries__lead_id')
+        leads_discarded = DiscardedEntry.objects\
+            .filter(analysis_pillar__analysis__in=analysis_ids)\
+            .order_by().values('analysis_pillar__analysis', 'entry__lead_id')
+        union_query = leads_dragged.union(leads_discarded).query
+
+        # NOTE: Django ORM union don't allow annotation
+        with django_db_connection.cursor() as cursor:
+            raw_sql = f'''
+                SELECT
+                    u.analysis_id,
+                    COUNT(DISTINCT(u.lead_id))
+                FROM ({union_query}) as u
+                GROUP BY u.analysis_id
+            '''
+            cursor.execute(raw_sql)
+            return {
+                analysis_id: lead_count
+                for analysis_id, lead_count in cursor.fetchall()
+            }
+
     @property
     def analyzed_sources(self):
         # FIXME: This generates N+1 query
-        leads_dragged = AnalyticalStatement.objects.filter(
-            analysis_pillar__analysis=self
-        ).order_by().values('entries__lead_id').distinct()
-        leads_discarded = DiscardedEntry.objects.filter(
-           analysis_pillar__analysis=self
-        ).order_by().values('entry__lead_id').distinct()
+        leads_dragged = AnalyticalStatement.objects\
+            .filter(analysis_pillar__analysis=self)\
+            .order_by().values('entries__lead_id').distinct()
+        leads_discarded = DiscardedEntry.objects\
+            .filter(analysis_pillar__analysis=self)\
+            .order_by().values('entry__lead_id').distinct()
         leads_total = leads_dragged.union(leads_discarded)
         return leads_total.count()
 
     @classmethod
-    def annotate_for_analysis_summary(cls, project_id, qs, user, filters=None):
+    def annotate_for_analysis_summary(cls, project_id, queryset, user, filters=None):
+        """
+        This is used by AnalysisSummarySerializer and AnalysisViewSet.get_summary
+        """
+        # NOTE: Models aren't loaded yet, so lazy importing.
         from entry.filter_set import get_filtered_entries
 
-        filters = filters or dict()
-        entries_filter_data = filters.get('entries_filter_data', {})
+        entries_filter_data = (filters or {}).get('entries_filter_data', {})
         total_entries = get_filtered_entries(user, entries_filter_data).count()
-        total_sources = Lead.objects.filter(
-            project=project_id
-        ).annotate(entries_count=models.Count('entry')).filter(entries_count__gt=0).count()
-        qs = qs.annotate(
-            team_lead_name=models.F('team_lead__username'),
-            dragged_entries=models.functions.Coalesce(
-                models.Subquery(
-                    AnalyticalStatement.objects.filter(
-                        analysis_pillar__analysis=models.OuterRef('pk')
-                    ).order_by().values('analysis_pillar__analysis').annotate(count=models.Count('entries', distinct=True))
-                    .values('count')[:1],
-                    output_field=models.IntegerField(),
-                ), 0),
-            discarded_entries=models.functions.Coalesce(
-                models.Subquery(
-                    DiscardedEntry.objects.filter(
-                        analysis_pillar__analysis=models.OuterRef('pk')
-                    ).order_by().values('analysis_pillar__analysis').annotate(count=models.Count('entry', distinct=True))
-                    .values('count')[:1],
-                    output_field=models.IntegerField(),
-                ), 0),
-            total_entries=models.Value(total_entries, output_field=models.IntegerField()),
-            total_sources=models.Value(total_sources, output_field=models.IntegerField())
+        total_sources = Lead.objects\
+            .filter(project=project_id)\
+            .annotate(entries_count=models.Count('entry'))\
+            .filter(entries_count__gt=0)\
+            .count()
+
+        # Prefetch for AnalysisSummaryPillarSerializer.
+        analysispillar_summary_prefetch = models.Prefetch(
+            'analysispillar_set',
+            queryset=(
+                AnalysisPillar.objects.select_related(
+                    'assignee',
+                    'assignee__profile',
+                ).annotate(
+                    dragged_entries=models.functions.Coalesce(models.Subquery(
+                        AnalyticalStatement.objects.filter(
+                            analysis_pillar=models.OuterRef('pk')
+                        ).order_by().values('analysis_pillar').annotate(count=models.Count('entries', distinct=True))
+                        .values('count')[:1],
+                        output_field=models.IntegerField(),
+                    ), 0),
+                    discarded_entries=models.functions.Coalesce(models.Subquery(
+                        DiscardedEntry.objects.filter(
+                            analysis_pillar=models.OuterRef('pk')
+                        ).order_by().values('analysis_pillar').annotate(count=models.Count('entry', distinct=True))
+                        .values('count')[:1],
+                        output_field=models.IntegerField(),
+                    ), 0),
+                    analyzed_entries=models.F('dragged_entries') + models.F('discarded_entries')
+                )
+            ),
+        )
+
+        # Subqueries
+        dragged_entries_subquery = models.functions.Coalesce(
+            models.Subquery(
+                AnalyticalStatement.objects.filter(
+                    analysis_pillar__analysis=models.OuterRef('pk')
+                ).order_by().values('analysis_pillar__analysis')
+                .annotate(count=models.Count('entries', distinct=True))
+                .values('count')[:1],
+                output_field=models.IntegerField(),
+            ), 0)
+        discarded_entries_subquery = models.functions.Coalesce(
+            models.Subquery(
+                DiscardedEntry.objects.filter(
+                    analysis_pillar__analysis=models.OuterRef('pk')
+                ).order_by().values('analysis_pillar__analysis')
+                .annotate(count=models.Count('entry', distinct=True))
+                .values('count')[:1],
+                output_field=models.IntegerField(),
+            ), 0)
+        publication_date_subquery = models.Subquery(
+            AnalyticalStatementEntry.objects.filter(
+                analytical_statement__analysis_pillar__analysis=models.OuterRef('pk'),
+            ).order_by().values('analytical_statement__analysis_pillar__analysis').annotate(
+                published_on_min=models.Min('entry__lead__published_on'),
+                published_on_max=models.Max('entry__lead__published_on'),
+            ).annotate(
+                publication_date=JSONObject(
+                    start_date=models.F('published_on_min'),
+                    end_date=models.F('published_on_max'),
+                )
+            ).values('publication_date')[:1],
+            output_field=models.JSONField(),
+        )
+
+        return queryset.select_related(
+            'team_lead',
+            'team_lead__profile',
+        ).prefetch_related(
+            analysispillar_summary_prefetch,
         ).annotate(
+            team_lead_name=models.F('team_lead__username'),
+            dragged_entries=dragged_entries_subquery,
+            discarded_entries=discarded_entries_subquery,
+            total_entries=models.Value(total_entries, output_field=models.IntegerField()),
+            total_sources=models.Value(total_sources, output_field=models.IntegerField()),
+            publication_date=publication_date_subquery,
             analyzed_entries=models.F('dragged_entries') + models.F('discarded_entries')
         )
-        return qs
 
 
 class AnalysisPillar(UserResource):
@@ -99,35 +186,35 @@ class AnalysisPillar(UserResource):
 
     @classmethod
     def annotate_for_analysis_pillar_summary(cls, qs):
-        qs = qs.annotate(
-            dragged_entries=models.functions.Coalesce(
-                models.Subquery(
-                    AnalyticalStatement.objects.filter(
-                        analysis_pillar=models.OuterRef('pk')
-                    ).order_by().values('analysis_pillar').annotate(count=models.Count('entries', distinct=True))
-                    .values('count')[:1],
-                    output_field=models.IntegerField(),
-                ), 0),
-            discarded_entries=models.functions.Coalesce(
-                models.Subquery(
-                    DiscardedEntry.objects.filter(
-                        analysis_pillar=models.OuterRef('pk')
-                    ).order_by().values('analysis_pillar__analysis').annotate(count=models.Count('entry', distinct=True))
-                    .values('count')[:1],
-                    output_field=models.IntegerField(),
-                ), 0),
-        ).annotate(
-            entries_analyzed=models.F('dragged_entries') + models.F('discarded_entries'),
-            analytical_statement_count=models.functions.Coalesce(
-                models.Subquery(
-                    AnalyticalStatement.objects.filter(
-                        analysis_pillar=models.OuterRef('pk')
-                    ).order_by().values('analysis_pillar').annotate(count=models.Count('id', distinct=True))
-                    .values('count')[:1],
-                    output_field=models.IntegerField(),
-                ),0)
-        )
-        return qs
+        return qs\
+            .annotate(
+                dragged_entries=models.functions.Coalesce(
+                    models.Subquery(
+                        AnalyticalStatement.objects.filter(
+                            analysis_pillar=models.OuterRef('pk')
+                        ).order_by().values('analysis_pillar').annotate(count=models.Count('entries', distinct=True))
+                        .values('count')[:1],
+                        output_field=models.IntegerField(),
+                    ), 0),
+                discarded_entries=models.functions.Coalesce(
+                    models.Subquery(
+                        DiscardedEntry.objects.filter(
+                            analysis_pillar=models.OuterRef('pk')
+                        ).order_by().values('analysis_pillar__analysis').annotate(count=models.Count('entry', distinct=True))
+                        .values('count')[:1],
+                        output_field=models.IntegerField(),
+                    ), 0),
+            ).annotate(
+                entries_analyzed=models.F('dragged_entries') + models.F('discarded_entries'),
+                analytical_statement_count=models.functions.Coalesce(
+                    models.Subquery(
+                        AnalyticalStatement.objects.filter(
+                            analysis_pillar=models.OuterRef('pk')
+                        ).order_by().values('analysis_pillar').annotate(count=models.Count('id', distinct=True))
+                        .values('count')[:1],
+                        output_field=models.IntegerField(),
+                    ), 0)
+            )
 
 
 class DiscardedEntry(models.Model):

--- a/apps/analysis/models.py
+++ b/apps/analysis/models.py
@@ -31,6 +31,18 @@ class Analysis(UserResource):
         analysis_cloned.save()
         return analysis_cloned
 
+    @property
+    def analyzed_sources(self):
+        # FIX ME: This generates N+1 query
+        leads_dragged = AnalyticalStatement.objects.filter(
+            analysis_pillar__analysis=self
+        ).order_by().values('entries__lead_id').distinct()
+        leads_discarded = DiscardedEntry.objects.filter(
+           analysis_pillar__analysis=self
+        ).order_by().values('entry__lead_id').distinct()
+        leads_total = leads_dragged.union(leads_discarded)
+        return leads_total.count()
+
 
 class AnalysisPillar(UserResource):
     title = models.CharField(max_length=255)

--- a/apps/analysis/serializers.py
+++ b/apps/analysis/serializers.py
@@ -80,7 +80,7 @@ class AnalysisPillarSerializer(
     NestedCreateMixin,
     NestedUpdateMixin,
 ):
-    assignee_name = serializers.CharField(source='assignee.username', read_only=True)
+    assignee_details = NanoUserSerializer(source='assignee', read_only=True)
     analysis_title = serializers.CharField(source='analysis.title', read_only=True)
     analytical_statements = AnalyticalStatementSerializer(many=True, source='analyticalstatement_set', required=False)
 
@@ -110,7 +110,7 @@ class AnalysisSerializer(
     NestedUpdateMixin,
 ):
     analysis_pillar = AnalysisPillarSerializer(many=True, source='analysispillar_set', required=False)
-    team_lead_name = serializers.CharField(source='team_lead.username', read_only=True)
+    team_lead_details = NanoUserSerializer(source='team_lead', read_only=True)
 
     class Meta:
         model = Analysis
@@ -156,3 +156,27 @@ class AnalysisSummarySerializer(serializers.ModelSerializer):
 
     def get_analyzed_sources(self, analysis):
         return self.context['analyzed_sources'].get(analysis.pk)
+
+
+class AnalysisPillarSummaryAnalyticalStatementSerializer(serializers.ModelSerializer):
+    entries_count = serializers.IntegerField(read_only=True)
+
+    class Meta:
+        model = AnalyticalStatement
+        fields = ('id', 'statement', 'entries_count')
+
+
+class AnalysisPillarSummarySerializer(serializers.ModelSerializer):
+    assignee_details = NanoUserSerializer(source='assignee', read_only=True)
+    analytical_statements = AnalysisPillarSummaryAnalyticalStatementSerializer(
+        source='analyticalstatement_set', many=True, read_only=True)
+    analyzed_entries = serializers.IntegerField(read_only=True)
+
+    class Meta:
+        model = AnalysisPillar
+        fields = (
+            'id', 'title', 'assignee', 'created_at',
+            'assignee_details',
+            'analytical_statements',
+            'analyzed_entries'
+        )

--- a/apps/analysis/serializers.py
+++ b/apps/analysis/serializers.py
@@ -139,8 +139,12 @@ class AnalysisSummarySerializer(serializers.ModelSerializer):
 
     class Meta:
         model = Analysis
-        fields = ('id', 'team_lead', 'team_lead_name', 'pillar_list', 'framework_overview', 'publication_date',
-                  'analyzed_entries', 'analyzed_sources', 'total_entries', 'total_sources', 'pillar_summary')
+        fields = ('id', 'title', 'team_lead', 'team_lead_name',
+                  'pillar_list', 'framework_overview', 'publication_date',
+                  'analyzed_entries', 'analyzed_sources', 'total_entries',
+                  'total_sources', 'pillar_summary',
+                  'created_at', 'modified_at',
+                )
 
     def get_pillar_list(self, analysis):
         return list(

--- a/apps/analysis/tests.py
+++ b/apps/analysis/tests.py
@@ -1,3 +1,0 @@
-from django.test import TestCase
-
-# Create your tests here.

--- a/apps/analysis/tests/test_apis.py
+++ b/apps/analysis/tests/test_apis.py
@@ -578,29 +578,22 @@ class TestAnalysisAPIs(TestCase):
         data = response.data['results']
         self.assertEqual(data[1]['team_lead'], user.id)
         self.assertEqual(data[1]['team_lead_name'], user.username)
-        self.assertEqual(len(data[1]['pillar_list']), 3)
-        self.assertEqual(data[1]['pillar_list'][0]['id'], pillar3.id)
-        self.assertEqual(data[1]['pillar_list'][1]['title'], pillar2.title)
-        self.assertEqual(data[1]['pillar_list'][2]['assignee_username'], pillar1.assignee.username)
+        self.assertEqual(data[1]['pillars'][0]['id'], pillar3.id)
+        self.assertEqual(data[1]['pillars'][1]['pillar_title'], pillar2.title)
+        self.assertEqual(data[1]['pillars'][2]['assignee_username'], pillar1.assignee.username)
         self.assertEqual(data[1]['publication_date']['start_date'], lead1.created_at.date())  # since we use lead that has entry created for
         self.assertEqual(data[1]['publication_date']['end_date'], lead2.created_at.date())
-        self.assertEqual(data[1]['framework_overview'][0]['title'], pillar3.title)
-        self.assertEqual(data[1]['framework_overview'][0]['entries_analyzed'], 3)  # discrded + analyzed entry
-        self.assertEqual(data[1]['framework_overview'][1]['entries_analyzed'], 2)  # discrded + analyzed entry
+        self.assertEqual(data[1]['pillars'][0]['analyzed_entries'], 3)  # discrded + analyzed entry
+        self.assertEqual(data[1]['pillars'][1]['analyzed_entries'], 2)  # discrded + analyzed entry
         self.assertEqual(data[1]['analyzed_entries'], 9)
         self.assertEqual(data[1]['analyzed_sources'], 6)  # have `distinct=True`
         self.assertEqual(data[1]['total_entries'], 10)
         self.assertEqual(data[1]['total_sources'], 8)  # taking lead that has entry more than one
         self.assertEqual(data[0]['team_lead'], user.id)
         self.assertEqual(data[0]['team_lead_name'], user.username)
-        self.assertEqual(data[0]['pillar_list'][0]['id'], pillar4.id)
+        self.assertEqual(data[0]['pillars'][0]['id'], pillar4.id)
         self.assertEqual(data[0]['analyzed_entries'], 4)
         self.assertEqual(data[0]['analyzed_sources'], 4)
-        self.assertEqual(data[0]['framework_overview'][0]['entries_analyzed'], 4)
-        self.assertEqual(data[1]['pillar_summary'][0]['id'], pillar3.id)
-        self.assertEqual(data[1]['pillar_summary'][0]['analytical_statement_count'], 1)
-        self.assertEqual(data[1]['pillar_summary'][0]['analytical_statements'][0]['entries_count'], 2)
-        self.assertEqual(data[1]['pillar_summary'][0]['entries_analyzed'], 3)  # discarded + dragged entries
 
         # try to post to api
         data = {

--- a/apps/analysis/tests/test_apis.py
+++ b/apps/analysis/tests/test_apis.py
@@ -570,7 +570,7 @@ class TestAnalysisAPIs(TestCase):
         self.authenticate(user)
         response = self.client.get(url)
         self.assert_200(response)
-        data = response.data
+        data = response.data['results']
         self.assertEqual(data[1]['team_lead'], user.id)
         self.assertEqual(data[1]['team_lead_name'], user.username)
         self.assertEqual(len(data[1]['pillar_list']), 3)

--- a/apps/analysis/tests/test_apis.py
+++ b/apps/analysis/tests/test_apis.py
@@ -502,10 +502,23 @@ class TestAnalysisAPIs(TestCase):
         now = timezone.now()
         lead1 = self.create_lead(project=project, created_at=now + relativedelta(days=-1))
         lead2 = self.create_lead(project=project, created_at=now)
+        lead3 = self.create_lead(project=project, created_at=now + relativedelta(days=-2))
+        lead4 = self.create_lead(project=project, created_at=now + relativedelta(days=-2))
+        lead5 = self.create_lead(project=project, created_at=now + relativedelta(days=-2))
+        lead6 = self.create_lead(project=project, created_at=now + relativedelta(days=-2))
+        self.create_lead(project=project, created_at=now + relativedelta(days=-2))
+        lead8 = self.create_lead(project=project, created_at=now + relativedelta(days=-2))
+        lead9 = self.create_lead(project=project, created_at=now + relativedelta(days=-2))
         self.create_lead(project=project, created_at=now + relativedelta(days=-3))
         entry = self.create_entry(lead=lead1, project=project)
         entry1 = self.create_entry(lead=lead2, project=project)
-        entry2 = self.create_entry(lead=lead1, project=project)
+        entry2 = self.create_entry(lead=lead3, project=project)
+        entry3 = self.create_entry(lead=lead4, project=project)
+        entry4 = self.create_entry(lead=lead5, project=project)
+        entry5 = self.create_entry(lead=lead6, project=project)
+        entry6 = self.create_entry(lead=lead6, project=project)
+        self.create_entry(lead=lead8, project=project)
+        entry8 = self.create_entry(lead=lead9, project=project)
         self.create_entry(lead=lead2, project=project)
 
         analysis1 = self.create(Analysis, title='Test Analysis', team_lead=user, project=project)
@@ -513,23 +526,45 @@ class TestAnalysisAPIs(TestCase):
         pillar1 = self.create(AnalysisPillar, analysis=analysis1, title='title1', assignee=user)
         pillar2 = self.create(AnalysisPillar, analysis=analysis1, title='title2', assignee=user)
         pillar3 = self.create(AnalysisPillar, analysis=analysis1, title='title3', assignee=user2)
+
         pillar4 = self.create(AnalysisPillar, analysis=analysis2, title='title3', assignee=user2)
 
         analytical_statement1 = self.create(AnalyticalStatement, analysis_pillar=pillar1)
         self.create(AnalyticalStatementEntry, analytical_statement=analytical_statement1, entry=entry)
         self.create(AnalyticalStatementEntry, analytical_statement=analytical_statement1, entry=entry1)
+        # lets discard some entry here
+        DiscardedEntry.objects.create(
+            analysis_pillar=pillar1,
+            entry=entry3,
+            tag=DiscardedEntry.TagType.REDUNDANT
+        )
 
         analytical_statement2 = self.create(AnalyticalStatement, analysis_pillar=pillar2)
-        self.create(AnalyticalStatementEntry, analytical_statement=analytical_statement2, entry=entry)
+        self.create(AnalyticalStatementEntry, analytical_statement=analytical_statement2, entry=entry4)
+        DiscardedEntry.objects.create(
+            analysis_pillar=pillar2,
+            entry=entry5,
+            tag=DiscardedEntry.TagType.REDUNDANT
+        )
 
         analytical_statement3 = self.create(AnalyticalStatement, analysis_pillar=pillar3)
-        self.create(AnalyticalStatementEntry, analytical_statement=analytical_statement3, entry=entry)
-        self.create(AnalyticalStatementEntry, analytical_statement=analytical_statement3, entry=entry1)
+        self.create(AnalyticalStatementEntry, analytical_statement=analytical_statement3, entry=entry5)
+        self.create(AnalyticalStatementEntry, analytical_statement=analytical_statement3, entry=entry6)
+        DiscardedEntry.objects.create(
+            analysis_pillar=pillar3,
+            entry=entry2,
+            tag=DiscardedEntry.TagType.REDUNDANT
+        )
 
         analytical_statement4 = self.create(AnalyticalStatement, analysis_pillar=pillar4)
         self.create(AnalyticalStatementEntry, analytical_statement=analytical_statement4, entry=entry)
         self.create(AnalyticalStatementEntry, analytical_statement=analytical_statement4, entry=entry1)
         self.create(AnalyticalStatementEntry, analytical_statement=analytical_statement4, entry=entry2)
+        DiscardedEntry.objects.create(
+            analysis_pillar=pillar4,
+            entry=entry8,
+            tag=DiscardedEntry.TagType.REDUNDANT
+        )
 
         url = f'/api/v1/projects/{project.id}/analysis/summary/'
         self.authenticate(user)
@@ -542,21 +577,25 @@ class TestAnalysisAPIs(TestCase):
         self.assertEqual(data[1]['pillar_list'][0]['id'], pillar3.id)
         self.assertEqual(data[1]['pillar_list'][1]['title'], pillar2.title)
         self.assertEqual(data[1]['pillar_list'][2]['assignee_username'], pillar1.assignee.username)
-        self.assertEqual(data[1]['analytical_statement_count'], 3)
-        self.assertEqual(data[1]['entries_used_in_analysis'], 3)
-        self.assertEqual(data[1]['analysis_overview']['entries_analyzed'], 2)
-        self.assertEqual(data[1]['analysis_overview']['sources_analyzed'], 2)
-        self.assertEqual(data[1]['total_sources'], 2)
-        self.assertEqual(data[1]['total_entries'], 4)
         self.assertEqual(data[1]['publication_date']['start_date'], lead1.created_at.date())  # since we use lead that has entry created for
         self.assertEqual(data[1]['publication_date']['end_date'], lead2.created_at.date())
         self.assertEqual(data[1]['framework_overview'][0]['title'], pillar3.title)
-        self.assertEqual(data[1]['framework_overview'][0]['entries_count'], 2)
-        self.assertEqual(data[1]['framework_overview'][1]['entries_count'], 1)
+        self.assertEqual(data[1]['framework_overview'][0]['entries_analyzed'], 3)  # discrded + analyzed entry
+        self.assertEqual(data[1]['framework_overview'][1]['entries_analyzed'], 2)  # discrded + analyzed entry
+        self.assertEqual(data[1]['analyzed_entries'], 8)
+        self.assertEqual(data[1]['analyzed_sources'], 7)  # have `distinct=True`
+        self.assertEqual(data[1]['total_entries'], 10)
+        self.assertEqual(data[1]['total_sources'], 8)  # taking lead that has entry more than one
         self.assertEqual(data[0]['team_lead'], user.id)
         self.assertEqual(data[0]['team_lead_name'], user.username)
-        self.assertEqual(data[0]['analysis_overview']['entries_analyzed'], 3)
-        self.assertEqual(data[0]['analysis_overview']['sources_analyzed'], 2)
+        self.assertEqual(data[0]['pillar_list'][0]['id'], pillar4.id)
+        self.assertEqual(data[0]['analyzed_entries'], 4)
+        self.assertEqual(data[0]['analyzed_sources'], 4)
+        self.assertEqual(data[0]['framework_overview'][0]['entries_analyzed'], 4)
+        self.assertEqual(data[1]['pillar_summary'][0]['id'], pillar3.id)
+        self.assertEqual(data[1]['pillar_summary'][0]['analytical_statement_count'], 1)
+        self.assertEqual(data[1]['pillar_summary'][0]['analytical_statements'][0]['entries_count'], 2)
+        self.assertEqual(data[1]['pillar_summary'][0]['entries_analyzed'], 3)  # discarded + dragged entries
 
         # try to post to api
         data = {

--- a/apps/analysis/tests/test_apis.py
+++ b/apps/analysis/tests/test_apis.py
@@ -519,7 +519,7 @@ class TestAnalysisAPIs(TestCase):
         entry6 = self.create_entry(lead=lead6, project=project)
         self.create_entry(lead=lead8, project=project)
         entry8 = self.create_entry(lead=lead9, project=project)
-        self.create_entry(lead=lead2, project=project)
+        entry9 = self.create_entry(lead=lead2, project=project)
 
         analysis1 = self.create(Analysis, title='Test Analysis', team_lead=user, project=project)
         analysis2 = self.create(Analysis, title='Not for test', team_lead=user, project=project)
@@ -536,6 +536,11 @@ class TestAnalysisAPIs(TestCase):
         DiscardedEntry.objects.create(
             analysis_pillar=pillar1,
             entry=entry3,
+            tag=DiscardedEntry.TagType.REDUNDANT
+        )
+        DiscardedEntry.objects.create(
+            analysis_pillar=pillar1,
+            entry=entry9,
             tag=DiscardedEntry.TagType.REDUNDANT
         )
 
@@ -582,7 +587,7 @@ class TestAnalysisAPIs(TestCase):
         self.assertEqual(data[1]['framework_overview'][0]['title'], pillar3.title)
         self.assertEqual(data[1]['framework_overview'][0]['entries_analyzed'], 3)  # discrded + analyzed entry
         self.assertEqual(data[1]['framework_overview'][1]['entries_analyzed'], 2)  # discrded + analyzed entry
-        self.assertEqual(data[1]['analyzed_entries'], 8)
+        self.assertEqual(data[1]['analyzed_entries'], 9)
         self.assertEqual(data[1]['analyzed_sources'], 7)  # have `distinct=True`
         self.assertEqual(data[1]['total_entries'], 10)
         self.assertEqual(data[1]['total_sources'], 8)  # taking lead that has entry more than one
@@ -912,23 +917,22 @@ class TestAnalysisAPIs(TestCase):
         self.assertNotIn(entry1.id, response_id)
 
     def test_discardedentry_options(self):
-        url = '/api/v1/discardedentry-options/'
+        url = '/api/v1/discarded-entry-options/'
 
         self.authenticate()
         response = self.client.get(url)
         self.assert_200(response)
-        self.assertIn('discarded_entries_tags', response.data)
         self.assertEqual(
-            response.data['discarded_entries_tags'][0]['key'],
+            response.data[0]['key'],
             DiscardedEntry.TagType.REDUNDANT)
         self.assertEqual(
-            response.data['discarded_entries_tags'][0]['value'],
+            response.data[0]['value'],
             DiscardedEntry.TagType.REDUNDANT.name.title()
         )
         self.assertEqual(
-            response.data['discarded_entries_tags'][1]['key'],
+            response.data[1]['key'],
             DiscardedEntry.TagType.TOO_OLD)
         self.assertEqual(
-            response.data['discarded_entries_tags'][1]['value'],
+            response.data[1]['value'],
             DiscardedEntry.TagType.TOO_OLD.name.title()
         )

--- a/apps/analysis/views.py
+++ b/apps/analysis/views.py
@@ -13,7 +13,6 @@ from rest_framework import (
 from deep.permissions import IsProjectMember
 from entry.views import EntryFilterView
 
-from entry.models import Entry
 from lead.models import Lead
 from .models import (
     Analysis,
@@ -105,7 +104,6 @@ class AnalysisViewSet(viewsets.ModelViewSet):
             total_sources=models.Value(total_sources, output_field=models.IntegerField())
         ).annotate(
             analyzed_entries=models.F('dragged_entries') + models.F('discarded_entries'),
-            analyzed_sources=models.F('sources_dragged') + models.F('sources_discarded')
         )
         self.page = self.paginate_queryset(queryset)
         serializer = AnalysisSummarySerializer(
@@ -244,13 +242,10 @@ class DiscardedEntryOptionsView(views.APIView):
     permission_classes = [permissions.IsAuthenticated]
 
     def get(self, request, version=None):
-        options = {
-            'discarded_entries_tags': [
+        options = [
                 {
-                    'key': entry.value,
-                    'value': entry.name.title()
-                } for entry in DiscardedEntry.TagType
-            ]
-        }
-
+                    'key': tag.value,
+                    'value': tag.name.title()
+                } for tag in DiscardedEntry.TagType
+        ]
         return response.Response(options)

--- a/apps/analysis/views.py
+++ b/apps/analysis/views.py
@@ -1,6 +1,4 @@
 from django.db import models
-from django.db.models.expressions import Subquery
-from django.db.models.fields import IntegerField
 
 from rest_framework.decorators import action
 from rest_framework import (
@@ -109,12 +107,13 @@ class AnalysisViewSet(viewsets.ModelViewSet):
             analyzed_entries=models.F('dragged_entries') + models.F('discarded_entries'),
             analyzed_sources=models.F('sources_dragged') + models.F('sources_discarded')
         )
+        self.page = self.paginate_queryset(queryset)
         serializer = AnalysisSummarySerializer(
-            queryset,
+            self.page,
             many=True,
             partial=True,
         )
-        return response.Response(serializer.data)
+        return self.get_paginated_response(serializer.data)
 
     @action(
         detail=True,

--- a/apps/project/permissions.py
+++ b/apps/project/permissions.py
@@ -8,6 +8,7 @@ from utils.data_structures import Dict
 PROJECT_PERMISSION_MODEL_MAP = {
     'lead': 'lead',
     'entry': 'entry',
+    'analysis': 'entry',
     'setup': 'setup',
     'export': 'export',
     'assessment': 'assessment',

--- a/apps/user/serializers.py
+++ b/apps/user/serializers.py
@@ -24,8 +24,18 @@ from jwt_auth.recaptcha import validate_recaptcha
 from jwt_auth.errors import (UserNotFoundError, InvalidCaptchaError)
 
 
-class SimpleUserSerializer(RemoveNullFieldsMixin,
-                           serializers.ModelSerializer):
+class NanoUserSerializer(RemoveNullFieldsMixin, serializers.ModelSerializer):
+    display_name = serializers.CharField(
+        source='profile.get_display_name',
+        read_only=True,
+    )
+
+    class Meta:
+        model = User
+        fields = ('id', 'display_name')
+
+
+class SimpleUserSerializer(RemoveNullFieldsMixin, serializers.ModelSerializer):
     display_name = serializers.CharField(
         source='profile.get_display_name',
         read_only=True,

--- a/deep/settings.py
+++ b/deep/settings.py
@@ -601,13 +601,6 @@ OTP_TOTP_ISSUER = f'Deep Admin {DEEP_ENVIRONMENT.title()}'
 OTP_EMAIL_SENDER = EMAIL_FROM
 OTP_EMAIL_SUBJECT = 'Deep Admin OTP Token'
 
-if DEBUG and not TESTING:
-    if os.environ.get('USE_SILK', 'False').lower() == 'true':
-        INSTALLED_APPS += ['silk']
-        MIDDLEWARE += ['silk.middleware.SilkyMiddleware']
-        SILKY_META = True
-        SILKY_PYTHON_PROFILER = True
-
 REDOC_SETTINGS = {
     'LAZY_RENDERING': True,
     'HIDE_HOSTNAME': True,
@@ -620,3 +613,17 @@ OPEN_API_DOCS_TIMEOUT = 86400  # 24 Hours
 ANALYTICAL_STATEMENT_COUNT = 30  # max no of analytical statement that can be created
 ANALYTICAL_ENTRIES_COUNT = 50  # max no of entries that can be created in analytical_statement
 DEFAULT_AUTO_FIELD = 'django.db.models.AutoField'
+
+# DEBUG TOOLBAR CONFIGURATION
+DEBUG_TOOLBAR_CONFIG = {
+    'DISABLE_PANELS': [
+        'debug_toolbar.panels.sql.SQLPanel',
+        'debug_toolbar.panels.staticfiles.StaticFilesPanel',
+        'debug_toolbar.panels.redirects.RedirectsPanel',
+        'debug_toolbar.panels.templates.TemplatesPanel',
+    ],
+}
+if DEBUG and 'DOCKER_HOST_IP' in os.environ:
+    INSTALLED_APPS += ['debug_toolbar']
+    MIDDLEWARE = ['debug_toolbar.middleware.DebugToolbarMiddleware'] + MIDDLEWARE
+    INTERNAL_IPS = [os.environ['DOCKER_HOST_IP']]

--- a/deep/settings.py
+++ b/deep/settings.py
@@ -623,6 +623,22 @@ DEBUG_TOOLBAR_CONFIG = {
         'debug_toolbar.panels.templates.TemplatesPanel',
     ],
 }
+DEBUG_TOOLBAR_PANELS = [
+    "debug_toolbar.panels.versions.VersionsPanel",
+    "debug_toolbar.panels.timer.TimerPanel",
+    "debug_toolbar.panels.settings.SettingsPanel",
+    "debug_toolbar.panels.headers.HeadersPanel",
+    "debug_toolbar.panels.request.RequestPanel",
+    "debug_toolbar.panels.sql.SQLPanel",
+    "debug_toolbar.panels.staticfiles.StaticFilesPanel",
+    "debug_toolbar.panels.templates.TemplatesPanel",
+    "debug_toolbar.panels.cache.CachePanel",
+    "debug_toolbar.panels.signals.SignalsPanel",
+    # ENABLING THIS WILL REMOVE LOGS FROM stdout "debug_toolbar.panels.logging.LoggingPanel",
+    "debug_toolbar.panels.redirects.RedirectsPanel",
+    "debug_toolbar.panels.profiling.ProfilingPanel",
+]
+
 if DEBUG and 'DOCKER_HOST_IP' in os.environ:
     INSTALLED_APPS += ['debug_toolbar']
     MIDDLEWARE = ['debug_toolbar.middleware.DebugToolbarMiddleware'] + MIDDLEWARE

--- a/deep/urls.py
+++ b/deep/urls.py
@@ -447,7 +447,7 @@ urlpatterns = [
         EntryOptionsView.as_view()),
     url(get_api_path(r'project-options/$'),
         ProjectOptionsView.as_view()),
-    url(get_api_path(r'discardedentry-options/$'),
+    url(get_api_path(r'discarded-entry-options/$'),
         DiscardedEntryOptionsView.as_view()),
 
     # Triggering api

--- a/deep/urls.py
+++ b/deep/urls.py
@@ -549,10 +549,13 @@ urlpatterns = [
     settings.MEDIA_URL, view=xframe_options_exempt(serve),
     document_root=settings.MEDIA_ROOT)
 
-if 'silk' in settings.INSTALLED_APPS:
-    urlpatterns += [
-        url(r'^silk/', include('silk.urls', namespace='silk')),
-    ]
+if settings.DEBUG:
+    import debug_toolbar
+    if 'debug_toolbar' in settings.INSTALLED_APPS:
+        urlpatterns += [
+            url('__debug__/', include(debug_toolbar.urls)),
+        ]
+
 
 handler404 = Api_404View.as_view()
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,9 @@
+# asgi-redis==1.4.3
 Markdown==3.0.1
 Pillow==5.4.1
 PyJWT==1.7.1
 Pygments==2.3.1
 Shapely==1.6.4.post2
-# asgi-redis==1.4.3
 beautifulsoup4==4.7.1
 boto3==1.9.88
 celery[redis]==4.2.1
@@ -11,25 +11,25 @@ coreapi==2.3.3
 dateparser==0.7.0
 decorator==4.3.2
 descartes==1.1.0
-django==3.2
-djangorestframework-camel-case==1.2.0
-djangorestframework==3.12.4
 django-celery-beat==1.4.0
 django-cors-headers==2.4.0
 django-crispy-forms==1.11.2
+django-debug-toolbar==3.2.1
 django-enumfield==2.0.2
 django-filter==2.4.0
 django-jsoneditor==0.1.2
+django-mptt==0.12.0
 django-ordered-model==3.3.0
 django-otp[qrcode]==0.6.0
 django-premailer==0.2.0
 django-redis==4.10.0
 django-reversion==3.0.9
-django-mptt==0.12.0
 django-ses==1.0.2
-django-silk==4.1.0
 django-storages==1.7.1
 django-utils-six
+django==3.2
+djangorestframework-camel-case==1.2.0
+djangorestframework==3.12.4
 drf-dynamic-fields==0.3.0
 drf-yasg[validation]==1.20.0
 feedparser==5.2.1
@@ -37,9 +37,9 @@ feedparser==5.2.1
 flower==0.9.2
 geopandas==0.4.0
 google-api-python-client==1.7.8
+graphene-django-extras==0.4.9
 graphene-django==2.15.0
 graphene-graphiql-explorer==0.0.1
-graphene-django-extras==0.4.9
 ipython==7.2.0
 kombu==4.6.3
 lxml==4.3.0

--- a/scripts/run_develop.sh
+++ b/scripts/run_develop.sh
@@ -1,6 +1,7 @@
 #!/bin/bash -x
 
 export PYTHONUNBUFFERED=1
+export DOCKER_HOST_IP=$(/sbin/ip route|awk '/default/ { print $3 }')
 PYTHON_MYPY_DEP_PATH=/code/.mypy-dep/
 
 pip3 install -r requirements.txt


### PR DESCRIPTION
Addresses - #3345
![2021-06-25-101148](https://user-images.githubusercontent.com/7059255/123369629-d086a980-d59d-11eb-9110-73adb5dd81f6.png)
![image](https://user-images.githubusercontent.com/38976661/123389335-7f84ae80-d5b9-11eb-8348-cb523aa379c6.png)

## Changes

- Update analysis summary API `/api/v1/projects/{project.id}/analysis/summary`. Added new fields
    - analyzedEntries
    - analyzedSources
    - publicationDate: {start_date, end_date } (Entry dragged lead's max-min publication dates)

- Change analysis-pillar summary API `/api/v1/projects/{project.id}/analysis/{analysis.id}/pillars/summary/`

- Breaking changes for consistency (Client partial diff: https://gist.github.com/thenav56/e77a7c24ab23baf0082200d97e3575b6)
    - `assigneeName` -> `assigneeDetails.displayName`
    - `teamLeadName` -> `teamLeadDetails.displayName`
    - `entriesAnalyzed` -> `analyzedEntries`

@samshara @AdityaKhatri

## This PR doesn't introduce any:

- [x] temporary files, auto-generated files or secret keys
- [x] n+1 queries
- [x] flake8 issues
- [x] `print`
- [ ] typos
- [x] unwanted comments

## This PR contains valid:

- [x] tests
- [ ] permission checks (tests here too)
- [ ] translations [Not required here..]