### PR TITLE
Create api to clone analyis-pillar

### DIFF
--- a/apps/analysis/models.py
+++ b/apps/analysis/models.py
@@ -49,6 +49,14 @@ class AnalysisPillar(UserResource):
     def __str__(self):
         return self.title
 
+    def clone_pillar(self):
+        pillar_cloned = copy.deepcopy(self)
+        pillar_cloned.pk = None
+        pillar_cloned.client_id = None
+        pillar_cloned.title = f'{self.title} (cloned)'
+        pillar_cloned.save()
+        return pillar_cloned
+
 
 class DiscardedEntry(models.Model):
     """

--- a/apps/analysis/models.py
+++ b/apps/analysis/models.py
@@ -49,12 +49,14 @@ class AnalysisPillar(UserResource):
     def __str__(self):
         return self.title
 
-    def clone_pillar(self):
+    def clone_pillar(self, title):
         pillar_cloned = copy.deepcopy(self)
         pillar_cloned.pk = None
         pillar_cloned.client_id = None
-        pillar_cloned.title = f'{self.title} (cloned)'
+        pillar_cloned.title = f'{title} (cloned)'
         pillar_cloned.save()
+        [statement.clone_to(pillar_cloned) for statement
+        in self.analyticalstatement_set.all()]
         return pillar_cloned
 
 
@@ -113,6 +115,16 @@ class AnalyticalStatement(UserResource):
     def __str__(self):
         return self.statement and self.statement[:255]
 
+    def clone_to(self, analysis_pillar):
+        cloned_statement = copy.deepcopy(self)
+        cloned_statement.pk = None
+        cloned_statement.client_id = None
+        cloned_statement.statement = self.statement
+        cloned_statement.analysis_pillar = analysis_pillar
+        cloned_statement.save()
+        [statement_entry.clone_to(cloned_statement) for statement_entry
+        in self.analyticalstatemententry_set.all()]
+        return cloned_statement
 
 class AnalyticalStatementEntry(UserResource):
     entry = models.ForeignKey(
@@ -128,3 +140,11 @@ class AnalyticalStatementEntry(UserResource):
     class Meta:
         ordering = ('order',)
         unique_together = ('entry', 'analytical_statement')
+
+    def clone_to(self, analytical_statement):
+        cloned_statement_entry = copy.deepcopy(self)
+        cloned_statement_entry.pk = None
+        cloned_statement_entry.client_id = None
+        cloned_statement_entry.analytical_statement = analytical_statement
+        cloned_statement_entry.save()
+        return cloned_statement_entry

--- a/apps/analysis/tests/test_apis.py
+++ b/apps/analysis/tests/test_apis.py
@@ -440,11 +440,10 @@ class TestAnalysisAPIs(TestCase):
             analysis_pillar=pillar,
             statement='Hello from here'
         )
-        self.create(
-            AnalyticalStatementEntry,
-            analytical_statement=analytical_statement,
-            entry=entry,
-            order=1
+        analytical_statement1 = self.create(
+            AnalyticalStatement,
+            analysis_pillar=pillar,
+            statement='Hello from there'
         )
         url = f'/api/v1/projects/{project.id}/analysis/{analysis.id}/pillars/{pillar.id}/clone-pillar/'
         data = {
@@ -457,9 +456,7 @@ class TestAnalysisAPIs(TestCase):
         self.assertNotEqual(response.data['id'], pillar.id)
         self.assertEqual(response.data['title'], f'{title}')
         self.assertIn('analytical_statements', response.data)
-        self.assertEqual(len(response.data['analytical_statements']), 1)
-        self.assertEqual(response.data['analytical_statements'][0]['statement'], analytical_statement.statement)
-        self.assertEqual(len(response.data['analytical_statements'][0]['analytical_entries']), 1)
+        self.assertEqual(len(response.data['analytical_statements']), 2)
 
         # authenticating with user that is not project member
         self.authenticate(user2)

--- a/apps/analysis/tests/test_apis.py
+++ b/apps/analysis/tests/test_apis.py
@@ -423,6 +423,29 @@ class TestAnalysisAPIs(TestCase):
         response = self.client.post(url, data)
         self.assert_403(response)
 
+    def test_clone_pillar(self):
+        user = self.create_user()
+        user2 = self.create_user()
+        project = self.create_project()
+        project.add_member(user)
+        analysis = self.create(Analysis, project=project)
+        pillar = self.create(AnalysisPillar, analysis=analysis, title="Test Clone")
+        url = f'/api/v1/projects/{project.id}/analysis/{analysis.id}/pillars/{pillar.id}/clone-pillar/'
+        data = {
+            'title': 'cloned_title',
+        }
+        self.authenticate(user)
+        response = self.client.post(url, data)
+        self.assert_201(response)
+
+        self.assertNotEqual(response.data['id'], pillar.id)
+        self.assertEqual(response.data['title'], f'{pillar.title} (cloned)')
+
+        # authenticating with user that is not project member
+        self.authenticate(user2)
+        response = self.client.post(url, data)
+        self.assert_403(response)
+
     def test_patch_analytical_statement(self):
         user = self.create_user()
         project = self.create_project()

--- a/apps/analysis/views.py
+++ b/apps/analysis/views.py
@@ -127,7 +127,9 @@ class AnalysisPillarViewSet(viewsets.ModelViewSet):
             raise exceptions.ValidationError({
                 'title': 'Title should be present',
             })
-        new_pillar = pillar.clone_pillar()
+        new_pillar = pillar.clone_pillar(
+            cloned_title
+        )
         serializer = AnalysisPillarSerializer(
             new_pillar,
             context={'request': request},

--- a/apps/analysis/views.py
+++ b/apps/analysis/views.py
@@ -127,9 +127,7 @@ class AnalysisPillarViewSet(viewsets.ModelViewSet):
             raise exceptions.ValidationError({
                 'title': 'Title should be present',
             })
-        new_pillar = pillar.clone_pillar(
-            cloned_title
-        )
+        new_pillar = pillar.clone_pillar(cloned_title)
         serializer = AnalysisPillarSerializer(
             new_pillar,
             context={'request': request},

--- a/apps/analysis/views.py
+++ b/apps/analysis/views.py
@@ -114,6 +114,29 @@ class AnalysisPillarViewSet(viewsets.ModelViewSet):
             'assignee'
         )
 
+    @action(
+        detail=True,
+        url_path='clone-pillar',
+        permission_classes=[IsProjectMember],
+        methods=['post']
+    )
+    def clone_pillar(self, request, project_id, analysis_id, pk=None, version=None):
+        pillar = self.get_object()
+        cloned_title = request.data.get('title').strip()
+        if not cloned_title:
+            raise exceptions.ValidationError({
+                'title': 'Title should be present',
+            })
+        new_pillar = pillar.clone_pillar()
+        serializer = AnalysisPillarSerializer(
+            new_pillar,
+            context={'request': request},
+        )
+        return response.Response(
+            serializer.data,
+            status=status.HTTP_201_CREATED,
+        )
+
 
 class AnalysisPillarDiscardedEntryViewSet(viewsets.ModelViewSet):
     serializer_class = DiscardedEntrySerializer


### PR DESCRIPTION
Addresses #802 

## Changes
- Cloning the analytical statement along with the analysis-pillars
- New API for the analysis-pillar clone
- Api `/api/v1/projects/{project.id}/analysis/{analysis.id}/pillars/{pillar.id}/clone-pillar/`
@AdityaKhatri 
## This PR doesn't introduce any:

- [x] temporary files, auto-generated files, or secret keys
- [x] n+1 queries
- [x] flake8 issues
- [x] `print`
- [x] typos
- [x] unwanted comments

## This PR contains valid:

- [x] tests
- [x] permission checks (tests here too)
- [] translations
