### PR TITLE
Show entries with project same as analysis project

### DIFF
--- a/apps/analysis/tests/test_apis.py
+++ b/apps/analysis/tests/test_apis.py
@@ -347,7 +347,7 @@ class TestAnalysisAPIs(TestCase):
         project.add_member(user)
         self.create_entry(project=project)
         self.create_entry(project=project)
-        analysis = self.create(Analysis, title='Test Analysis')
+        analysis = self.create(Analysis, title='Test Analysis', project=project)
         url = f'/api/v1/projects/{project.id}/analysis/{analysis.id}/pillars/'
         data = {
             'main_statement': 'Some main statement',
@@ -365,7 +365,7 @@ class TestAnalysisAPIs(TestCase):
         self.authenticate(user)
         response = self.client.post(url, data)
         self.assert_201(response)
-        id = response.data['id']
+        response_id = response.data['id']
         statement_id = response.data['analytical_statements'][0]['id']
         self.assertEqual(response.data['version_id'], 1)
         # try to patch some changes in analytical_statements
@@ -383,7 +383,8 @@ class TestAnalysisAPIs(TestCase):
                 },
             ]
         }
-        url = f'/api/v1/projects/{project.id}/analysis/{analysis.id}/pillars/{id}/'
+        url = f'/api/v1/projects/{project.id}/analysis/{analysis.id}/pillars/{response_id}/'
+        self.authenticate(user)
         response = self.client.patch(url, data)
         self.assert_200(response)
         # after the sucessfull patch the version should change
@@ -393,9 +394,9 @@ class TestAnalysisAPIs(TestCase):
         user = self.create_user()
         project = self.create_project()
         project.add_member(user)
-        entry1 = self.create(Entry)
-        entry2 = self.create(Entry)
-        analysis = self.create(Analysis, title='Test Analysis')
+        entry1 = self.create_entry(project=project)
+        entry2 = self.create_entry(project=project)
+        analysis = self.create(Analysis, title='Test Analysis', project=project)
         url = f'/api/v1/projects/{project.id}/analysis/{analysis.id}/pillars/'
         data = {
             'main_statement': 'Some main statement',
@@ -480,6 +481,7 @@ class TestAnalysisAPIs(TestCase):
             ]
         }
         url = f'/api/v1/projects/{project.id}/analysis/{analysis.id}/pillars/{response_id}/'
+        self.authenticate(user)
         response = self.client.patch(url, data)
         self.assert_400(response)
         self.assertEqual(

--- a/apps/analysis/tests/test_apis.py
+++ b/apps/analysis/tests/test_apis.py
@@ -871,20 +871,24 @@ class TestAnalysisAPIs(TestCase):
     def test_all_entries_in_analysis_pillar(self):
         user = self.create_user()
         project = self.create_project()
+        project2 = self.create_project()
         project.add_member(user)
+        project2.add_member(user)
         analysis = self.create(Analysis, project=project)
         pillar = self.create(AnalysisPillar, analysis=analysis)
         entry1 = self.create(Entry, project=project)
         self.create(Entry, project=project)
         self.create(Entry, project=project)
         self.create(Entry, project=project)
+        self.create(Entry, project=project2)
 
         # Check the entry count
         analysis_pillar_entries_url = f'/api/v1/analysis-pillar/{pillar.id}/entries/'
         self.authenticate(user)
         response = self.client.post(analysis_pillar_entries_url)
         self.assert_200(response)
-        self.assertEqual(len(response.data['results']), 4)  # this should list all the entries present
+        # this should output only the entries that have same project as the analysis project
+        self.assertEqual(len(response.data['results']), 4)
 
         # now try to discard the entry from the discarded entries api
         data = {

--- a/apps/analysis/views.py
+++ b/apps/analysis/views.py
@@ -1,3 +1,5 @@
+from django.shortcuts import get_object_or_404
+
 from rest_framework.decorators import action
 from rest_framework import (
     exceptions,
@@ -125,6 +127,10 @@ class AnalysisPillarEntryViewSet(EntryFilterView):
         queryset = super().get_queryset()
         filters = self.get_entries_filters()
         analysis_pillar_id = self.kwargs['analysis_pillar_id']
+        analysis_pillar  = get_object_or_404(AnalysisPillar, id=self.kwargs['analysis_pillar_id'])
+        queryset = queryset.filter(
+            project=analysis_pillar.analysis.project
+        )
         discarded_entries_qs = DiscardedEntry.objects.filter(analysis_pillar=analysis_pillar_id).values('entry')
         if filters.get('discarded'):
             return queryset.filter(id__in=discarded_entries_qs)


### PR DESCRIPTION

## Changes
- Show the entries of the same project as the analysis project

## This PR doesn't introduce any:

- [x] temporary files, auto-generated files or secret keys
- [x] n+1 queries
- [x] flake8 issues
- [x] `print`
- [x] typos
- [x] unwanted comments

## This PR contains valid:

- [x] tests
- [ ] permission checks (tests here too)
- [ ] translations
