### PR TITLE
Add start_date and end_date in analysis summary api

### DIFF
--- a/apps/analysis/serializers.py
+++ b/apps/analysis/serializers.py
@@ -176,6 +176,7 @@ class AnalysisSummarySerializer(serializers.ModelSerializer):
         fields = (
             'id', 'title', 'team_lead', 'team_lead_details',
             'publication_date', 'pillars',
+            'start_date', 'end_date',
             'analyzed_entries', 'analyzed_sources', 'total_entries',
             'total_sources', 'created_at', 'modified_at',
         )

--- a/apps/analysis/tests/test_apis.py
+++ b/apps/analysis/tests/test_apis.py
@@ -699,6 +699,7 @@ class TestAnalysisAPIs(TestCase):
         self.assert_200(response)
         data = response.data['results']
         self.assertEqual(data[1]['team_lead'], user.id)
+        self.assertEqual(data[1]['end_date'], analysis1.end_date.strftime('%Y-%m-%d'))
         self.assertEqual(data[1]['team_lead_details']['id'], user.id)
         self.assertEqual(data[1]['team_lead_details']['display_name'], user.profile.get_display_name())
         self.assertEqual(data[1]['pillars'][0]['id'], pillar3.id)


### PR DESCRIPTION

## Changes
- Added end_date and start_date in analysis summary API

Mention related users here if any.

## This PR doesn't introduce any:

- [x] temporary files, auto-generated files or secret keys
- [x] n+1 queries
- [x] flake8 issues
- [x] `print`
- [x] typos
- [x] unwanted comments

## This PR contains valid:

- [x] tests
- [ ] permission checks (tests here too)
- [ ] translations
