### PR TITLE
Fix django filter issues after django version upgrade

### DIFF
--- a/apps/ary/tests/test_apis.py
+++ b/apps/ary/tests/test_apis.py
@@ -288,7 +288,7 @@ class AssessmentTests(TestCase):
         self.update_obj(self.create(Assessment, lead=lead3, project=project), created_at=now + relativedelta(days=-2))
         self.update_obj(self.create(Assessment, lead=lead4, project=project), created_at=now)
 
-        params = {'created_at__gt': now.strftime('%Y-%m-%d%z')}
+        params = {'created_at__gte': now.strftime('%Y-%m-%d%z')}
         url = f'/api/v1/assessments/'
         self.authenticate()
         respose = self.client.get(url, params)
@@ -306,22 +306,42 @@ class AssessmentTests(TestCase):
     def test_assessment_options_in_project(self):
         user1 = self.create_user()
         user2 = self.create_user()
+        lead1 = self.create_lead()
+        lead2 = self.create_lead()
+        lead3 = self.create_lead()
         project1 = self.create(Project)
         project1.add_member(user1)
         project2 = self.create(Project)
-        project2.add_member(user2)
         project2.add_member(user1)
+        project2.add_member(user2)
+        self.create(Assessment, lead=lead1, project=project2, created_by=user1)
+        self.create(Assessment, lead=lead2, project=project2, created_by=user2)
+        self.create(Assessment, lead=lead3, project=project1, created_by=user2)
 
-        # filter by project
+        # filter by project2
         url = f'/api/v1/assessment-options/?project={project2.id}'
         self.authenticate(user1)
         response = self.client.get(url)
         self.assert_200(response)
-        self.assertIn(project2.id, [item['key'] for item in response.data['project']])
-        self.assertIn(project2.title, [item['value'] for item in response.data['project']])
-        # gives the member of the project
-        self.assertIn(user1.id, [item['key'] for item in response.data['created_by']])
+        projects = response.data['project']
+        self.assertEqual(len(projects), 1)
+        self.assertEqual(projects[0]['key'], project2.id, projects)
+        self.assertEqual(projects[0]['value'], project2.title, projects)
+        # gives all the assessment that the user has created for the project
         self.assertEqual(
             set([item['key'] for item in response.data['created_by']]),
             set([user1.id, user2.id])
         )
+
+        # filter by project1
+        url = f'/api/v1/assessment-options/?project={project1.id}'
+        self.authenticate(user1)
+        response = self.client.get(url)
+        self.assert_200(response)
+        projects = response.data['project']
+        self.assertEqual(len(projects), 1)
+        self.assertEqual(projects[0]['key'], project1.id, projects)
+        self.assertEqual(projects[0]['value'], project1.title, projects)
+        # gives all the assessment that the user has created for the project
+        self.assertEqual(user2.id, response.data['created_by'][0]['key'])
+        self.assertEqual(len(response.data['created_by']), 1)

--- a/apps/lead/filter_set.py
+++ b/apps/lead/filter_set.py
@@ -73,7 +73,6 @@ class LeadFilterSet(django_filters.FilterSet):
     )
     assignee = django_filters.ModelMultipleChoiceFilter(
         queryset=User.objects.all(),
-        lookup_expr='in',
         widget=django_filters.widgets.CSVWidget,
     )
     classified_doc_id = NumberInFilter(

--- a/apps/lead/tests/test_apis.py
+++ b/apps/lead/tests/test_apis.py
@@ -1028,6 +1028,27 @@ class LeadTests(TestCase):
         response = self.client.get(f'{url}&exists={LeadFilterSet.ASSESSMENT_DOES_NOT_EXIST}')
         assert response.json()['count'] == 1, 'Lead count should be 1 for lead without assessment'
 
+    def test_lead_assignee_filter(self):
+        user1 = self.create_user()
+        user2 = self.create_user()
+        user3 = self.create_user()
+        project = self.create_project()
+        self.create_lead(project=project, assignee=[user1, user2])
+        self.create_lead(project=project, assignee=[user1])
+        self.create_lead(project=project, assignee=[user2])
+        url = f'/api/v1/leads/?assignee={user1.id}'
+
+        self.authenticate()
+        response = self.client.get(url)
+        assert len(response.data['results']) == 2
+
+        # filter by user who is not assignee in any of the lead
+        url = f'/api/v1/leads/?assignee={user3.id}'
+
+        self.authenticate()
+        response = self.client.get(url)
+        assert len(response.data['results']) == 0
+
     def test_lead_authoring_organization_type_filter(self):
         url = '/api/v1/leads/?authoring_organization_types={}'
 

--- a/apps/lead/tests/test_apis.py
+++ b/apps/lead/tests/test_apis.py
@@ -1038,14 +1038,15 @@ class LeadTests(TestCase):
         self.create_lead(project=project, assignee=[user2])
         url = f'/api/v1/leads/?assignee={user1.id}'
 
+        # authenticate user
         self.authenticate()
+
+        # filter by user who is assignee in some leads
         response = self.client.get(url)
         assert len(response.data['results']) == 2
 
         # filter by user who is not assignee in any of the lead
         url = f'/api/v1/leads/?assignee={user3.id}'
-
-        self.authenticate()
         response = self.client.get(url)
         assert len(response.data['results']) == 0
 

--- a/apps/user_resource/filters.py
+++ b/apps/user_resource/filters.py
@@ -4,16 +4,24 @@ import django_filters
 
 class UserResourceFilterSet(django_filters.FilterSet):
     created_at__lt = django_filters.DateFilter(
-        field_name='created_at', lookup_expr='lte',
+        field_name='created_at',
+        lookup_expr='lte',
+        input_formats=['%Y-%m-%d%z']
     )
     created_at__gt = django_filters.DateFilter(
-        field_name='created_at', lookup_expr='gte',
+        field_name='created_at',
+        lookup_expr='gte',
+        input_formats=['%Y-%m-%d%z']
     )
     modified_at__lt = django_filters.DateFilter(
-        field_name='modified_at', lookup_expr='lte',
+        field_name='modified_at',
+        lookup_expr='lte',
+        input_formats=['%Y-%m-%d%z']
     )
     modified_at__gt = django_filters.DateFilter(
-        field_name='modified_at', lookup_expr='gte',
+        field_name='modified_at',
+        lookup_expr='gte',
+        input_formats=['%Y-%m-%d%z']
     )
     created_by = django_filters.ModelMultipleChoiceFilter(
         queryset=User.objects.all())

--- a/apps/user_resource/filters.py
+++ b/apps/user_resource/filters.py
@@ -8,7 +8,7 @@ class UserResourceFilterSet(django_filters.FilterSet):
         lookup_expr='lte',
         input_formats=['%Y-%m-%d%z']
     )
-    created_at__gt = django_filters.DateFilter(
+    created_at__gte = django_filters.DateFilter(
         field_name='created_at',
         lookup_expr='gte',
         input_formats=['%Y-%m-%d%z']


### PR DESCRIPTION
Addresses 
 - When filtered by Created date filter, getting 400 Bad Request error(#https://zube.io/deep/deep/c/3509)
 - When filtered by Assignee, we are facing 500 Internal Server Error(#https://zube.io/deep/deep/c/3508)
 - In Assessments form, when searched by Created By proper list is not been displayed(#https://zube.io/deep/deep/c/3510)

## Changes
- Fixed Django filter issue after version upgrade

Mention related users here if any.

## This PR doesn't introduce any:

- [x] temporary files, auto-generated files or secret keys
- [x] n+1 queries
- [x] flake8 issues
- [x] `print`
- [x] typos
- [x] unwanted comments

## This PR contains valid:

- [x] tests
- [ ] permission checks (tests here too)
- [ ] translations
