### PR TITLE
Fix project filter in lead-group api

### DIFF
--- a/apps/lead/filter_set.py
+++ b/apps/lead/filter_set.py
@@ -242,7 +242,6 @@ class LeadFilterSet(django_filters.FilterSet):
 class LeadGroupFilterSet(UserResourceFilterSet):
     project = django_filters.ModelMultipleChoiceFilter(
         queryset=Project.objects.all(),
-        lookup_expr='in',
         widget=django_filters.widgets.CSVWidget,
     )
 


### PR DESCRIPTION
Addresses #869 

## Changes
- Fixed project filter in the lead-group api

Mention related users here if any.

## This PR doesn't introduce any:

- [x] temporary files, auto-generated files or secret keys
- [x] n+1 queries
- [x] flake8 issues
- [x] `print`
- [x] typos
- [x] unwanted comments

## This PR contains valid:

- [x] tests
- [ ] permission checks (tests here too)
- [ ] translations
