### PR TITLE
Add filter to exclude regions in project

### DIFF
--- a/apps/geo/filter_set.py
+++ b/apps/geo/filter_set.py
@@ -54,7 +54,7 @@ class RegionFilterSet(UserResourceFilterSet):
 
     def exclude_project_region_filter(self, qs, name, value):
         if value:
-            return qs.filter(~models.Q(project__in=value)).distinct()
+            return qs.exclude(project__in=value).distinct()
         return qs
 
 

--- a/apps/geo/filter_set.py
+++ b/apps/geo/filter_set.py
@@ -1,6 +1,14 @@
 import django_filters
+from django.db import models
 
-from geo.models import GeoArea
+from geo.models import (
+    AdminLevel,
+    GeoArea,
+    Region,
+)
+from project.models import Project
+from user_resource.filters import UserResourceFilterSet
+
 
 class GeoAreaFilterSet(django_filters.rest_framework.FilterSet):
     label = django_filters.CharFilter(
@@ -16,3 +24,54 @@ class GeoAreaFilterSet(django_filters.rest_framework.FilterSet):
         if value:
             return queryset.filter(label__icontains=value)
         return queryset
+
+
+class RegionFilterSet(UserResourceFilterSet):
+    """
+    Region filter set
+
+    Filter by code, title and public fields
+    """
+    # NOTE: This filter the regions not in the supplied project
+    exclude_project = django_filters.ModelMultipleChoiceFilter(
+        method='exclude_project_region_filter',
+        widget=django_filters.widgets.CSVWidget,
+        queryset=Project.objects.all(),
+    )
+
+    class Meta:
+        model = Region
+        fields = ['id', 'code', 'title', 'public', 'project',
+                  'created_at', 'created_by', 'modified_at', 'modified_by']
+        filter_overrides = {
+            models.CharField: {
+                'filter_class': django_filters.CharFilter,
+                'extra': lambda f: {
+                    'lookup_expr': 'icontains',
+                },
+            },
+        }
+
+    def exclude_project_region_filter(self, qs, name, value):
+        if value:
+            return qs.filter(~models.Q(project__in=value)).distinct()
+        return qs
+
+
+class AdminLevelFilterSet(django_filters.rest_framework.FilterSet):
+    """
+    AdminLevel filter set
+
+    Filter by title, region and parent
+    """
+    class Meta:
+        model = AdminLevel
+        fields = ['id', 'title', 'region', 'parent']
+        filter_overrides = {
+            models.CharField: {
+                'filter_class': django_filters.CharFilter,
+                'extra': lambda f: {
+                    'lookup_expr': 'icontains',
+                },
+            },
+        }

--- a/apps/geo/views.py
+++ b/apps/geo/views.py
@@ -3,6 +3,7 @@ from django.contrib.gis.geos import GEOSGeometry
 from django.contrib.gis.gdal.error import GDALException
 from django.conf import settings
 from django.db import models
+
 from rest_framework import (
     exceptions,
     filters,
@@ -19,8 +20,6 @@ from deep.permissions import (
     ModifyPermission,
     IsProjectMember
 )
-from user_resource.filters import UserResourceFilterSet
-
 from project.models import Project
 from .models import Region, AdminLevel, GeoArea
 from .serializers import (
@@ -28,28 +27,12 @@ from .serializers import (
     RegionSerializer,
     GeoAreaSerializer
 )
-from .filter_set import GeoAreaFilterSet
+from .filter_set import (
+    GeoAreaFilterSet,
+    AdminLevelFilterSet,
+    RegionFilterSet
+)
 from geo.tasks import load_geo_areas
-
-
-class RegionFilterSet(UserResourceFilterSet):
-    """
-    Region filter set
-
-    Filter by code, title and public fields
-    """
-    class Meta:
-        model = Region
-        fields = ['id', 'code', 'title', 'public', 'project',
-                  'created_at', 'created_by', 'modified_at', 'modified_by']
-        filter_overrides = {
-            models.CharField: {
-                'filter_class': django_filters.CharFilter,
-                'extra': lambda f: {
-                    'lookup_expr': 'icontains',
-                },
-            },
-        }
 
 
 class RegionViewSet(viewsets.ModelViewSet):
@@ -123,25 +106,6 @@ class RegionCloneView(views.APIView):
 
         return response.Response(serializer.data,
                                  status=status.HTTP_201_CREATED)
-
-
-class AdminLevelFilterSet(django_filters.rest_framework.FilterSet):
-    """
-    AdminLevel filter set
-
-    Filter by title, region and parent
-    """
-    class Meta:
-        model = AdminLevel
-        fields = ['id', 'title', 'region', 'parent']
-        filter_overrides = {
-            models.CharField: {
-                'filter_class': django_filters.CharFilter,
-                'extra': lambda f: {
-                    'lookup_expr': 'icontains',
-                },
-            },
-        }
 
 
 class AdminLevelViewSet(viewsets.ModelViewSet):


### PR DESCRIPTION
Addresses #872 

## Changes
- Added exclude project regions filter in `/api/v1/regions/` api

Mention related users here if any.
@subinasr 
## This PR doesn't introduce any:

- [x] temporary files, auto-generated files or secret keys
- [x] n+1 queries
- [x] flake8 issues
- [x] `print`
- [x] typos
- [x] unwanted comments

## This PR contains valid:

- [x] tests
- [ ] permission checks (tests here too)
- [ ] translations
