### PR TITLE
Remove dynamicfieldmixin from analysis role serializer

### DIFF
--- a/apps/analysis_framework/serializers.py
+++ b/apps/analysis_framework/serializers.py
@@ -92,7 +92,7 @@ class SimpleExportableSerializer(RemoveNullFieldsMixin,
 
 
 class AnalysisFrameworkRoleSerializer(
-    RemoveNullFieldsMixin, DynamicFieldsMixin, serializers.ModelSerializer,
+    RemoveNullFieldsMixin, serializers.ModelSerializer,
 ):
     class Meta:
         model = AnalysisFrameworkRole


### PR DESCRIPTION
## Changes

* Remove dynamic field mixin from AnalysisFrameworkRoleSerializer

## This PR doesn't introduce any:

- [x] temporary files, auto-generated files or secret keys
- [x] n+1 queries
- [x] flake8 issues
- [x] `print`
- [x] typos
- [x] unwanted comments

## This PR contains valid:

- [ ] tests
- [ ] permission checks (tests here too)
- [ ] translations
