### PR TITLE
New api for user-group memberships

### DIFF
--- a/apps/user_group/models.py
+++ b/apps/user_group/models.py
@@ -3,6 +3,7 @@ from django.db import models
 
 from user_resource.models import UserResource
 
+
 class UserGroup(UserResource):
     """
     User group model
@@ -103,3 +104,9 @@ class GroupMembership(models.Model):
 
     def can_modify(self, user):
         return self.group.can_modify(user)
+
+    @staticmethod
+    def get_member_for_user_group(user_group):
+        return GroupMembership.objects.filter(
+            group=user_group
+        ).distinct()

--- a/apps/user_group/serializers.py
+++ b/apps/user_group/serializers.py
@@ -5,6 +5,7 @@ from deep.serializers import RemoveNullFieldsMixin
 from user_group.models import UserGroup, GroupMembership
 from user_resource.serializers import UserResourceSerializer
 
+
 class SimpleUserGroupSerializer(RemoveNullFieldsMixin,
                                 serializers.ModelSerializer):
     class Meta:

--- a/apps/user_group/views.py
+++ b/apps/user_group/views.py
@@ -1,13 +1,15 @@
+from django.db import models
 
 from rest_framework import (
     permissions,
     viewsets,
 )
 from rest_framework.decorators import action
-from django.db import models
 
-from deep.permissions import ModifyPermission
-
+from deep.permissions import (
+    ModifyPermission,
+    IsUserGroupMember
+)
 from utils.db.functions import StrPos
 from .models import (
     GroupMembership,
@@ -37,6 +39,19 @@ class UserGroupViewSet(viewsets.ModelViewSet):
         user_groups = UserGroup.get_for_member(user)
 
         self.page = self.paginate_queryset(user_groups)
+        serializer = self.get_serializer(self.page, many=True)
+        return self.get_paginated_response(serializer.data)
+
+    @action(
+        detail=True,
+        permission_classes=[permissions.IsAuthenticated, IsUserGroupMember],
+        serializer_class=GroupMembershipSerializer,
+        url_path='memberships',
+    )
+    def get_usergroup_member(self, request, pk, version=None):
+        user_group = self.get_object()
+        members = GroupMembership.get_member_for_user_group(user_group)
+        self.page = self.paginate_queryset(members)
         serializer = self.get_serializer(self.page, many=True)
         return self.get_paginated_response(serializer.data)
 

--- a/deep/permissions.py
+++ b/deep/permissions.py
@@ -7,6 +7,7 @@ from project.permissions import PROJECT_PERMISSIONS
 from lead.models import Lead
 from entry.models import Entry
 from analysis.models import AnalysisPillar
+from user_group.models import UserGroup
 
 logger = logging.getLogger(__name__)
 
@@ -179,4 +180,14 @@ class IsProjectMember(permissions.BasePermission):
     def has_object_permission(self, request, view, obj):
         if type(obj) == Project:
             return obj.members.filter(id=request.user.id).exists()
+        return True
+
+
+class IsUserGroupMember(permissions.BasePermission):
+    message = 'Only allowed for UserGroup members'
+
+    def has_permission(self, request, view):
+        user_group_id = view.kwargs.get('pk')
+        if user_group_id:
+            return UserGroup.get_for_member(request.user).filter(id=user_group_id).exists()
         return True


### PR DESCRIPTION
Addresses 
- New Project Flow: User Group issues(https://zube.io/deep/deep/c/3724)

## Changes
New API for user-group memberships
- `/api/v1/user-groups/{user_group.id}/memberships/`

Mention related users here if any.
@AdityaKhatri 
## This PR doesn't introduce any:

- [x] temporary files, auto-generated files or secret keys
- [x] n+1 queries
- [x] flake8 issues
- [x] `print`
- [x] typos
- [x] unwanted comments

## This PR contains valid:

- [x] tests
- [x] permission checks (tests here too)
- [ ] translations
