### PR TITLE
Add members_count in user_groups/member_of api

### DIFF
--- a/apps/user_group/models.py
+++ b/apps/user_group/models.py
@@ -33,9 +33,9 @@ class UserGroup(UserResource):
 
     @staticmethod
     def get_for_member(user):
-        return UserGroup.objects.annotate(
-            members_count=models.Count('members', distinct=True)
-        ).filter(members=user).distinct()
+        return UserGroup.objects.filter(
+            members=user
+        ).distinct()
 
     @staticmethod
     def get_modifiable_for(user):

--- a/apps/user_group/models.py
+++ b/apps/user_group/models.py
@@ -33,9 +33,9 @@ class UserGroup(UserResource):
 
     @staticmethod
     def get_for_member(user):
-        return UserGroup.objects.filter(
-            members=user
-        ).distinct()
+        return UserGroup.objects.annotate(
+            members_count=models.Count('members', distinct=True)
+        ).filter(members=user).distinct()
 
     @staticmethod
     def get_modifiable_for(user):

--- a/apps/user_group/serializers.py
+++ b/apps/user_group/serializers.py
@@ -54,14 +54,16 @@ class UserGroupSerializer(
         required=False,
     )
     role = serializers.SerializerMethodField()
+    members_count = serializers.IntegerField(read_only=True)
 
     class Meta:
         model = UserGroup
-        fields = ('id', 'title', 'description', 'display_picture', 'role',
-                  'memberships', 'global_crisis_monitoring',
-                  'custom_project_fields', 'created_at', 'modified_at',
-                  'created_by', 'modified_by'
-                )
+        fields = (
+            'id', 'title', 'description', 'display_picture', 'role',
+            'memberships', 'global_crisis_monitoring',
+            'custom_project_fields', 'created_at', 'modified_at',
+            'created_by', 'modified_by', 'members_count'
+        )
 
     def create(self, validated_data):
         user_group = super().create(validated_data)

--- a/apps/user_group/tests/test_apis.py
+++ b/apps/user_group/tests/test_apis.py
@@ -49,24 +49,30 @@ class UserGroupApiTest(TestCase):
         self.assertEqual(response.data['results'][0]['created_by'], user.id)
 
     def test_member_of(self):
-        user_group = self.create(UserGroup, role='admin')
-        test_user = self.create(User)
+        user_group1 = self.create(UserGroup, role='admin')
+        user_group2 = self.create(UserGroup, role='admin')
+        test_user1 = self.create(User)
+        test_user2 = self.create(User)
+        GroupMembership.objects.create(member=test_user1, group=user_group1)
+        GroupMembership.objects.create(member=test_user2, group=user_group1)
+        GroupMembership.objects.create(member=test_user2, group=user_group2)
 
         url = '/api/v1/user-groups/member-of/'
 
         self.authenticate()
         response = self.client.get(url)
         self.assert_200(response)
+        self.assertEqual(response.data['count'], 2)
+        self.assertEqual(response.data['results'][0]['id'], user_group1.id)
 
-        self.assertEqual(response.data['count'], 1)
-        self.assertEqual(response.data['results'][0]['id'], user_group.id)
-
-        url = '/api/v1/user-groups/member-of/?user={}'.format(test_user.id)
-
+        url = '/api/v1/user-groups/member-of/?user={}'.format(test_user1.id)
         response = self.client.get(url)
         self.assert_200(response)
-
-        self.assertEqual(response.data['count'], 0)
+        self.assertEqual(response.data['count'], 1)
+        self.assertEqual(response.data['results'][0]['id'], user_group1.id)
+        # check for the member count
+        # NOTE: count 3 since a member is created whenever a usergroup is created
+        self.assertEqual(response.data['results'][0]['members_count'], 3)
 
     def test_search_user_group_without_exclusion(self):
         project = self.create(Project)

--- a/apps/user_group/tests/test_apis.py
+++ b/apps/user_group/tests/test_apis.py
@@ -63,8 +63,10 @@ class UserGroupApiTest(TestCase):
         response = self.client.get(url)
         self.assert_200(response)
         self.assertEqual(response.data['count'], 2)
-        self.assertEqual(response.data['results'][0]['id'], user_group1.id)
-
+        self.assertEqual(
+            set([user_group['id'] for user_group in response.data['results']]),
+            set([user_group1.id, user_group2.id])
+        )
         url = '/api/v1/user-groups/member-of/?user={}'.format(test_user1.id)
         response = self.client.get(url)
         self.assert_200(response)

--- a/apps/user_group/views.py
+++ b/apps/user_group/views.py
@@ -37,7 +37,6 @@ class UserGroupViewSet(viewsets.ModelViewSet):
     def get_for_member(self, request, version=None):
         user = self.request.GET.get('user', self.request.user)
         user_groups = UserGroup.get_for_member(user)
-
         self.page = self.paginate_queryset(user_groups)
         serializer = self.get_serializer(self.page, many=True)
         return self.get_paginated_response(serializer.data)


### PR DESCRIPTION
Addresses 
- New Project Flow: User Group issues(https://zube.io/deep/deep/c/3724)
## Changes
 - Added members_count in `api/v1/user-groups/member-of/?user={}` api

Mention related users here if any.

## This PR doesn't introduce any:

- [x] temporary files, auto-generated files or secret keys
- [x] n+1 queries
- [x] flake8 issues
- [x] `print`
- [x] typos
- [x] unwanted comments

## This PR contains valid:

- [x] tests
- [ ] permission checks (tests here too)
- [ ] translations
