### PR TITLE
Add auto generated client_id in cloned analysis

### DIFF
--- a/apps/analysis/models.py
+++ b/apps/analysis/models.py
@@ -7,6 +7,7 @@ from django.db import connection as django_db_connection
 from django.utils.translation import gettext_lazy as _
 
 from project.mixins import ProjectEntityMixin
+from deep.number_generator import client_id_generator
 from user.models import User
 from project.models import Project
 from entry.models import Entry
@@ -42,20 +43,20 @@ class Analysis(UserResource, ProjectEntityMixin):
         def _get_clone_pillar(obj, analysis_cloned_id):
             obj.cloned_from_id = obj.pk
             obj.pk = None
-            obj.client_id = None
+            obj.client_id = client_id_generator()
             obj.analysis_id = analysis_cloned_id
             return obj
 
         def _get_clone_pillar_statement(obj, analysis_pillar_id):
             obj.cloned_from_id = obj.pk
             obj.pk = None
-            obj.client_id = None
+            obj.client_id = client_id_generator()
             obj.analysis_pillar_id = analysis_pillar_id
             return obj
 
         def _get_clone_statement_entry(obj, analytical_statement_id):
             obj.pk = None
-            obj.client_id = None
+            obj.client_id = client_id_generator()
             obj.analytical_statement_id = analytical_statement_id
             return obj
 
@@ -65,7 +66,7 @@ class Analysis(UserResource, ProjectEntityMixin):
             return obj
 
         analysis_cloned.pk = None
-        analysis_cloned.client_id = None
+        analysis_cloned.client_id = client_id_generator()
         analysis_cloned.title = title
         analysis_cloned.end_date = end_date
         analysis_cloned.cloned_from = self

--- a/apps/analysis/tests/test_apis.py
+++ b/apps/analysis/tests/test_apis.py
@@ -1106,8 +1106,8 @@ class TestAnalysisAPIs(TestCase):
         lead2 = self.create_lead(project=project, title='TESTA', published_on=now + relativedelta(days=-4))
         lead3 = self.create_lead(project=project, title='TESTA', published_on=now + relativedelta(days=-2))
         entry1 = self.create(Entry, project=project, lead=lead2)
-        self.create(Entry, project=project, lead=lead2)
-        self.create(Entry, project=project, lead=lead3)
+        entry2 = self.create(Entry, project=project, lead=lead2)
+        entry3 = self.create(Entry, project=project, lead=lead3)
         self.create(Entry, project=project, lead=lead1)
         self.create(Entry, project=project2, lead=lead3)
 
@@ -1138,6 +1138,14 @@ class TestAnalysisAPIs(TestCase):
         response = self.post_filter_test(analysis_pillar_entries_url, {'discarded': False}, count=2)
         response_id = [res['id'] for res in response.data['results']]
         self.assertNotIn(entry1.id, response_id)
+
+        # try to exclude some entries
+        self.authenticate(user)
+        data = {
+            'exclude_entries': [entry2.id, entry3.id]
+        }
+        response = self.post_filter_test(analysis_pillar_entries_url, data, count=0)
+        self.assert_200(response)
 
     def test_discardedentry_options(self):
         url = '/api/v1/discarded-entry-options/'

--- a/apps/analysis/views.py
+++ b/apps/analysis/views.py
@@ -141,7 +141,11 @@ class AnalysisPillarEntryViewSet(EntryFilterView):
         discarded_entries_qs = DiscardedEntry.objects.filter(analysis_pillar=analysis_pillar_id).values('entry')
         if filters.get('discarded'):
             return queryset.filter(id__in=discarded_entries_qs)
-        return queryset.exclude(id__in=discarded_entries_qs)
+        queryset = queryset.exclude(id__in=discarded_entries_qs)
+        exclude_entries = filters.get('exclude_entries')
+        if exclude_entries:
+            queryset = queryset.exclude(id__in=exclude_entries)
+        return queryset
 
 
 class AnalyticalStatementViewSet(viewsets.ModelViewSet):

--- a/deep/number_generator.py
+++ b/deep/number_generator.py
@@ -1,0 +1,6 @@
+import string
+import random
+
+
+def client_id_generator(size=16, chars=string.ascii_uppercase + string.digits):
+    return ''.join(random.choice(chars) for _ in range(size))


### PR DESCRIPTION
## Changes
- Add 16 characters auto-generated client_id incase of analysis clone

Mention related users here if any.

## This PR doesn't introduce any:

- [x] temporary files, auto-generated files or secret keys
- [x] n+1 queries
- [x] flake8 issues
- [x] `print`
- [x] typos
- [x] unwanted comments

## This PR contains valid:

- [x] tests
- [ ] permission checks (tests here too)
- [ ] translations
