### PR TITLE
Add export type filter

### DIFF
--- a/apps/export/filter_set.py
+++ b/apps/export/filter_set.py
@@ -23,6 +23,21 @@ class ExportFilterSet(django_filters.rest_framework.FilterSet):
         widget=django_filters.widgets.CSVWidget
     )
 
+    type = django_filters.MultipleChoiceFilter(
+        choices=Export.DATA_TYPES,
+        widget=django_filters.widgets.CSVWidget
+    )
+    exported_at__lt = django_filters.DateFilter(
+        field_name='exported_at',
+        lookup_expr='lte',
+        input_formats=['%Y-%m-%d%z']
+    )
+    exported_at__gte = django_filters.DateFilter(
+        field_name='exported_at',
+        lookup_expr='gte',
+        input_formats=['%Y-%m-%d%z']
+    )
+
     class Meta:
         model = Export
         fields = ['is_archived']

--- a/apps/export/tests/test_apis.py
+++ b/apps/export/tests/test_apis.py
@@ -133,10 +133,9 @@ class ExportTests(TestCase):
         assert response.json()['count'] == 2
 
     def test_export_filter_by_type(self):
-        self.create(Export, exported_by=self.user, type=Export.ENTRIES)
-        self.create(Export, exported_by=self.user, type=Export.ASSESSMENTS)
-        self.create(Export, exported_by=self.user, type=Export.ASSESSMENTS)
-        self.create(Export, exported_by=self.user, type=Export.PLANNED_ASSESSMENTS)
+        types = [Export.ENTRIES, Export.ASSESSMENTS, Export.ASSESSMENTS, Export.PLANNED_ASSESSMENTS]
+        for type in types:
+            self.create(Export, exported_by=self.user, type=type)
 
         self.authenticate()
         response = self.client.get(f'/api/v1/exports/?type={Export.ASSESSMENTS}')
@@ -146,10 +145,9 @@ class ExportTests(TestCase):
 
     def test_export_filter_by_exported_at(self):
         now = timezone.now()
-        self.update_obj(self.create(Export, exported_by=self.user), exported_at=now + relativedelta(days=+2))
-        self.update_obj(self.create(Export, exported_by=self.user), exported_at=now + relativedelta(days=+3))
-        self.update_obj(self.create(Export, exported_by=self.user), exported_at=now + relativedelta(days=+4))
-        self.update_obj(self.create(Export, exported_by=self.user), exported_at=now + relativedelta(days=-2))
+        days = [2, 3, 4, -2]
+        for day in days:
+            self.update_obj(self.create(Export, exported_by=self.user), exported_at=now + relativedelta(days=day))
         self.update_obj(self.create(Export, exported_by=self.user), exported_at=now)
 
         params = {'exported_at__gte': now.strftime('%Y-%m-%d%z')}

--- a/apps/export/tests/test_apis.py
+++ b/apps/export/tests/test_apis.py
@@ -1,3 +1,6 @@
+from dateutil.relativedelta import relativedelta
+
+from django.utils import timezone
 from django.core.cache import cache
 
 from deep.tests import TestCase
@@ -128,6 +131,33 @@ class ExportTests(TestCase):
         assert response.json()['count'] == 4
         response = self.client.get(f'/api/v1/exports/?status={Export.PENDING},{Export.FAILURE}')
         assert response.json()['count'] == 2
+
+    def test_export_filter_by_type(self):
+        self.create(Export, exported_by=self.user, type=Export.ENTRIES)
+        self.create(Export, exported_by=self.user, type=Export.ASSESSMENTS)
+        self.create(Export, exported_by=self.user, type=Export.ASSESSMENTS)
+        self.create(Export, exported_by=self.user, type=Export.PLANNED_ASSESSMENTS)
+
+        self.authenticate()
+        response = self.client.get(f'/api/v1/exports/?type={Export.ASSESSMENTS}')
+        assert response.json()['count'] == 2
+        response = self.client.get(f'/api/v1/exports/?type={Export.ASSESSMENTS},{Export.ENTRIES}')
+        assert response.json()['count'] == 3
+
+    def test_export_filter_by_exported_at(self):
+        now = timezone.now()
+        self.update_obj(self.create(Export, exported_by=self.user), exported_at=now + relativedelta(days=+2))
+        self.update_obj(self.create(Export, exported_by=self.user), exported_at=now + relativedelta(days=+3))
+        self.update_obj(self.create(Export, exported_by=self.user), exported_at=now + relativedelta(days=+4))
+        self.update_obj(self.create(Export, exported_by=self.user), exported_at=now + relativedelta(days=-2))
+        self.update_obj(self.create(Export, exported_by=self.user), exported_at=now)
+
+        params = {'exported_at__gte': now.strftime('%Y-%m-%d%z')}
+        url = '/api/v1/exports/'
+        self.authenticate()
+        respose = self.client.get(url, params)
+        self.assert_200(respose)
+        self.assertEqual(len(respose.data['results']), 4)
 
     def test_export_filter_by_archived(self):
         self.create(Export, exported_by=self.user, is_archived=False)


### PR DESCRIPTION
Addresses 
- https://github.com/the-deep/server/issues/906

## Changes
- Added `exported_at` and `type` filter in export

Mention related users here if any.

## This PR doesn't introduce any:

- [x] temporary files, auto-generated files or secret keys
- [x] n+1 queries
- [x] flake8 issues
- [x] `print`
- [x] typos
- [x] unwanted comments

## This PR contains valid:

- [x] tests
- [ ] permission checks (tests here too)
- [ ] translations
