### PR TITLE
Feature/setup graphene file upload

### DIFF
--- a/apps/analysis_framework/schema.py
+++ b/apps/analysis_framework/schema.py
@@ -49,6 +49,7 @@ class AnalysisFrameworkType(DjangoObjectType):
         only_fields = (
             'id', 'title', 'description', 'is_private', 'organization',
             'created_by', 'created_at', 'modified_by', 'modified_at',
+            'preview_image',
         )
 
     current_user_role = graphene.String()
@@ -102,6 +103,7 @@ class AnalysisFrameworkDetailType(AnalysisFrameworkType):
         only_fields = (
             'id', 'title', 'description', 'is_private', 'organization',
             'created_by', 'created_at', 'modified_by', 'modified_at',
+            'preview_image',
         )
 
     @staticmethod

--- a/apps/analysis_framework/tests/test_mutations.py
+++ b/apps/analysis_framework/tests/test_mutations.py
@@ -16,7 +16,10 @@ class TestPreviewImage(GraphQLFileUploadTestCase, GraphQLTestCase):
                 result {
                   id
                   title
-                  previewImage
+                  previewImage {
+                      name
+                      url
+                  }
                 }
               }
             }
@@ -25,7 +28,10 @@ class TestPreviewImage(GraphQLFileUploadTestCase, GraphQLTestCase):
         query RetrieveAFQuery {
           analysisFramework(id: %s) {
             id
-            previewImage
+            previewImage {
+                name
+                url
+            }
           }
         }
         """
@@ -54,16 +60,22 @@ class TestPreviewImage(GraphQLFileUploadTestCase, GraphQLTestCase):
             )
         content = response.json()
         self.assertResponseNoErrors(response)
+
         # Test can upload image
         af_id = content['data']['analysisFrameworkCreate']['result']['id']
         self.assertTrue(content['data']['analysisFrameworkCreate']['ok'], content)
-        self.assertTrue(content['data']['analysisFrameworkCreate']['result']['previewImage'])
-        preview_image_name = content['data']['analysisFrameworkCreate']['result']['previewImage']
+        self.assertTrue(content['data']['analysisFrameworkCreate']['result']['previewImage']["name"])
+        preview_image_name = content['data']['analysisFrameworkCreate']['result']['previewImage']["name"]
+        preview_image_url = content['data']['analysisFrameworkCreate']['result']['previewImage']["url"]
         self.assertTrue(preview_image_name.endswith('.png'))
+        self.assertTrue(preview_image_url.endswith(preview_image_name))
 
         # Test can retrive image
         response = self.query(self.retrieve_af_query % af_id)
+        self.assertResponseNoErrors(response)
         content = response.json()
-        self.assertTrue(content['data']['analysisFramework']['previewImage'])
-        preview_image_name = content['data']['analysisFramework']['previewImage']
+        self.assertTrue(content['data']['analysisFramework']['previewImage']["name"])
+        preview_image_name = content['data']['analysisFramework']['previewImage']["name"]
+        preview_image_url = content['data']['analysisFramework']['previewImage']["url"]
         self.assertTrue(preview_image_name.endswith('.png'))
+        self.assertTrue(preview_image_url.endswith(preview_image_name))

--- a/apps/analysis_framework/tests/test_mutations.py
+++ b/apps/analysis_framework/tests/test_mutations.py
@@ -1,0 +1,69 @@
+import json
+from django.core.files.temp import NamedTemporaryFile
+from utils.graphene.tests import GraphQLTestCase
+from user.factories import UserFactory
+from graphene_file_upload.django.testing import GraphQLFileUploadTestCase
+
+
+class TestPreviewImage(GraphQLFileUploadTestCase, GraphQLTestCase):
+    def setUp(self) -> None:
+        self.user = UserFactory.create()
+        self.upload_mutation = """
+            mutation Mutation($data: AnalysisFrameworkInputType!) {
+              analysisFrameworkCreate(data: $data) {
+                ok
+                errors
+                result {
+                  id
+                  title
+                  previewImage
+                }
+              }
+            }
+        """
+        self.retrieve_af_query = """
+        query RetrieveAFQuery {
+          analysisFramework(id: %s) {
+            id
+            previewImage
+          }
+        }
+        """
+        self.variables = {
+            "data": {"title": 'test', "previewImage": None}
+        }
+        self.force_login(self.user)
+
+    def test_upload_preview_image(self):
+        file_text = b'preview image text'
+        with NamedTemporaryFile(suffix='.png') as t_file:
+            t_file.write(file_text)
+            t_file.seek(0)
+            response = self._client.post(
+                '/graphql',
+                data={
+                    'operations': json.dumps({
+                        'query': self.upload_mutation,
+                        'variables': self.variables
+                    }),
+                    't_file': t_file,
+                    'map': json.dumps({
+                        't_file': ['variables.data.previewImage']
+                    })
+                }
+            )
+        content = response.json()
+        self.assertResponseNoErrors(response)
+        # Test can upload image
+        af_id = content['data']['analysisFrameworkCreate']['result']['id']
+        self.assertTrue(content['data']['analysisFrameworkCreate']['ok'], content)
+        self.assertTrue(content['data']['analysisFrameworkCreate']['result']['previewImage'])
+        preview_image_name = content['data']['analysisFrameworkCreate']['result']['previewImage']
+        self.assertTrue(preview_image_name.endswith('.png'))
+
+        # Test can retrive image
+        response = self.query(self.retrieve_af_query % af_id)
+        content = response.json()
+        self.assertTrue(content['data']['analysisFramework']['previewImage'])
+        preview_image_name = content['data']['analysisFramework']['previewImage']
+        self.assertTrue(preview_image_name.endswith('.png'))

--- a/deep/views.py
+++ b/deep/views.py
@@ -12,6 +12,7 @@ from django.views.generic import View
 from django.conf import settings
 from django.template.response import TemplateResponse
 from graphene_django.views import GraphQLView
+from graphene_file_upload.django import FileUploadGraphQLView
 
 from deep.graphene_context import GQLContext
 from deep.exceptions import PermissionDeniedException
@@ -198,7 +199,7 @@ class EntryReviewCommentEmail(View):
             request, 'entry/review_comment_notification_email.html', context)
 
 
-class CustomGraphQLView(GraphQLView):
+class CustomGraphQLView(FileUploadGraphQLView):
     def get_context(self, request):
         return GQLContext(request)
 

--- a/poetry.lock
+++ b/poetry.lock
@@ -1029,6 +1029,23 @@ reference = "v0.4.9-patch.1"
 resolved_reference = "8dcb7b900a323fade2d4c019839f1417b0356bef"
 
 [[package]]
+name = "graphene-file-upload"
+version = "1.3.0"
+description = "Lib for adding file upload functionality to GraphQL mutations in Graphene Django and Flask-Graphql"
+category = "main"
+optional = false
+python-versions = "*"
+
+[package.dependencies]
+six = ">=1.11.0"
+
+[package.extras]
+all = ["Flask (>=1.0.2)", "graphene (>=2.1.2)", "Flask-Graphql (>=2.0.0)", "graphene-django (>=2.0.0)"]
+django = ["graphene-django (>=2.0.0)"]
+flask = ["Flask (>=1.0.2)", "graphene (>=2.1.2)", "Flask-Graphql (>=2.0.0)"]
+tests = ["coverage", "pytest", "pytest-cov", "pytest-django"]
+
+[[package]]
 name = "graphene-graphiql-explorer"
 version = "0.0.1"
 description = "A Django app that adds graphiql explorer to the graphiql view"
@@ -2375,7 +2392,7 @@ python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.8"
-content-hash = "04bcfe61b2022a56975a61845018deabff93234a6812403560d134a9aee994d2"
+content-hash = "974c2ea64fac3ec1fd4275a5146a802b409748cb9bbb0d48d7087ae73dab7618"
 
 [metadata.files]
 amqp = [
@@ -2687,6 +2704,10 @@ graphene-django = [
     {file = "graphene_django-2.15.0-py2.py3-none-any.whl", hash = "sha256:02671d195f0c09c8649acff2a8f4ad4f297d0f7d98ea6e6cdf034b81bab92880"},
 ]
 graphene-django-extras = []
+graphene-file-upload = [
+    {file = "graphene_file_upload-1.3.0-py3-none-any.whl", hash = "sha256:5afe50f409f50e3d198fd92c883d98d868e6c6aaadf5df3a3f4d88ecad90ed97"},
+    {file = "graphene_file_upload-1.3.0.tar.gz", hash = "sha256:6898480b0556826472c80971032917c01968ade5800d84054008fe598795b063"},
+]
 graphene-graphiql-explorer = [
     {file = "graphene_graphiql_explorer-0.0.1-py2.py3-none-any.whl", hash = "sha256:09fa61cfa8b44f989b471f333e1cba1eda08855fee8bf03fd446f305e4268b14"},
     {file = "graphene_graphiql_explorer-0.0.1.tar.gz", hash = "sha256:db00e192118897c78611f10d8b8c2062b6297a2e964b0c004b2ecee1f14d4165"},
@@ -2804,6 +2825,8 @@ lxml = [
     {file = "lxml-4.6.3-cp27-cp27m-win_amd64.whl", hash = "sha256:8157dadbb09a34a6bd95a50690595e1fa0af1a99445e2744110e3dca7831c4ee"},
     {file = "lxml-4.6.3-cp27-cp27mu-manylinux1_i686.whl", hash = "sha256:7728e05c35412ba36d3e9795ae8995e3c86958179c9770e65558ec3fdfd3724f"},
     {file = "lxml-4.6.3-cp27-cp27mu-manylinux1_x86_64.whl", hash = "sha256:4bff24dfeea62f2e56f5bab929b4428ae6caba2d1eea0c2d6eb618e30a71e6d4"},
+    {file = "lxml-4.6.3-cp310-cp310-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_24_i686.whl", hash = "sha256:64812391546a18896adaa86c77c59a4998f33c24788cadc35789e55b727a37f4"},
+    {file = "lxml-4.6.3-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_24_x86_64.whl", hash = "sha256:c1a40c06fd5ba37ad39caa0b3144eb3772e813b5fb5b084198a985431c2f1e8d"},
     {file = "lxml-4.6.3-cp35-cp35m-manylinux1_i686.whl", hash = "sha256:74f7d8d439b18fa4c385f3f5dfd11144bb87c1da034a466c5b5577d23a1d9b51"},
     {file = "lxml-4.6.3-cp35-cp35m-manylinux1_x86_64.whl", hash = "sha256:f90ba11136bfdd25cae3951af8da2e95121c9b9b93727b1b896e3fa105b2f586"},
     {file = "lxml-4.6.3-cp35-cp35m-manylinux2010_i686.whl", hash = "sha256:4c61b3a0db43a1607d6264166b230438f85bfed02e8cff20c22e564d0faff354"},
@@ -2849,12 +2872,22 @@ markdown = [
     {file = "Markdown-3.3.4.tar.gz", hash = "sha256:31b5b491868dcc87d6c24b7e3d19a0d730d59d3e46f4eea6430a321bed387a49"},
 ]
 markupsafe = [
+    {file = "MarkupSafe-2.0.1-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:d8446c54dc28c01e5a2dbac5a25f071f6653e6e40f3a8818e8b45d790fe6ef53"},
+    {file = "MarkupSafe-2.0.1-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:36bc903cbb393720fad60fc28c10de6acf10dc6cc883f3e24ee4012371399a38"},
+    {file = "MarkupSafe-2.0.1-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:2d7d807855b419fc2ed3e631034685db6079889a1f01d5d9dac950f764da3dad"},
+    {file = "MarkupSafe-2.0.1-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:add36cb2dbb8b736611303cd3bfcee00afd96471b09cda130da3581cbdc56a6d"},
+    {file = "MarkupSafe-2.0.1-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:168cd0a3642de83558a5153c8bd34f175a9a6e7f6dc6384b9655d2697312a646"},
+    {file = "MarkupSafe-2.0.1-cp310-cp310-win32.whl", hash = "sha256:99df47edb6bda1249d3e80fdabb1dab8c08ef3975f69aed437cb69d0a5de1e28"},
+    {file = "MarkupSafe-2.0.1-cp310-cp310-win_amd64.whl", hash = "sha256:e0f138900af21926a02425cf736db95be9f4af72ba1bb21453432a07f6082134"},
     {file = "MarkupSafe-2.0.1-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:f9081981fe268bd86831e5c75f7de206ef275defcb82bc70740ae6dc507aee51"},
     {file = "MarkupSafe-2.0.1-cp36-cp36m-manylinux1_i686.whl", hash = "sha256:0955295dd5eec6cb6cc2fe1698f4c6d84af2e92de33fbcac4111913cd100a6ff"},
     {file = "MarkupSafe-2.0.1-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:0446679737af14f45767963a1a9ef7620189912317d095f2d9ffa183a4d25d2b"},
     {file = "MarkupSafe-2.0.1-cp36-cp36m-manylinux2010_i686.whl", hash = "sha256:f826e31d18b516f653fe296d967d700fddad5901ae07c622bb3705955e1faa94"},
     {file = "MarkupSafe-2.0.1-cp36-cp36m-manylinux2010_x86_64.whl", hash = "sha256:fa130dd50c57d53368c9d59395cb5526eda596d3ffe36666cd81a44d56e48872"},
     {file = "MarkupSafe-2.0.1-cp36-cp36m-manylinux2014_aarch64.whl", hash = "sha256:905fec760bd2fa1388bb5b489ee8ee5f7291d692638ea5f67982d968366bef9f"},
+    {file = "MarkupSafe-2.0.1-cp36-cp36m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:bf5d821ffabf0ef3533c39c518f3357b171a1651c1ff6827325e4489b0e46c3c"},
+    {file = "MarkupSafe-2.0.1-cp36-cp36m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:0d4b31cc67ab36e3392bbf3862cfbadac3db12bdd8b02a2731f509ed5b829724"},
+    {file = "MarkupSafe-2.0.1-cp36-cp36m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:baa1a4e8f868845af802979fcdbf0bb11f94f1cb7ced4c4b8a351bb60d108145"},
     {file = "MarkupSafe-2.0.1-cp36-cp36m-win32.whl", hash = "sha256:6c4ca60fa24e85fe25b912b01e62cb969d69a23a5d5867682dd3e80b5b02581d"},
     {file = "MarkupSafe-2.0.1-cp36-cp36m-win_amd64.whl", hash = "sha256:b2f4bf27480f5e5e8ce285a8c8fd176c0b03e93dcc6646477d4630e83440c6a9"},
     {file = "MarkupSafe-2.0.1-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:0717a7390a68be14b8c793ba258e075c6f4ca819f15edfc2a3a027c823718567"},
@@ -2863,14 +2896,21 @@ markupsafe = [
     {file = "MarkupSafe-2.0.1-cp37-cp37m-manylinux2010_i686.whl", hash = "sha256:d7f9850398e85aba693bb640262d3611788b1f29a79f0c93c565694658f4071f"},
     {file = "MarkupSafe-2.0.1-cp37-cp37m-manylinux2010_x86_64.whl", hash = "sha256:6a7fae0dd14cf60ad5ff42baa2e95727c3d81ded453457771d02b7d2b3f9c0c2"},
     {file = "MarkupSafe-2.0.1-cp37-cp37m-manylinux2014_aarch64.whl", hash = "sha256:b7f2d075102dc8c794cbde1947378051c4e5180d52d276987b8d28a3bd58c17d"},
+    {file = "MarkupSafe-2.0.1-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e9936f0b261d4df76ad22f8fee3ae83b60d7c3e871292cd42f40b81b70afae85"},
+    {file = "MarkupSafe-2.0.1-cp37-cp37m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:2a7d351cbd8cfeb19ca00de495e224dea7e7d919659c2841bbb7f420ad03e2d6"},
+    {file = "MarkupSafe-2.0.1-cp37-cp37m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:60bf42e36abfaf9aff1f50f52644b336d4f0a3fd6d8a60ca0d054ac9f713a864"},
     {file = "MarkupSafe-2.0.1-cp37-cp37m-win32.whl", hash = "sha256:a30e67a65b53ea0a5e62fe23682cfe22712e01f453b95233b25502f7c61cb415"},
     {file = "MarkupSafe-2.0.1-cp37-cp37m-win_amd64.whl", hash = "sha256:611d1ad9a4288cf3e3c16014564df047fe08410e628f89805e475368bd304914"},
+    {file = "MarkupSafe-2.0.1-cp38-cp38-macosx_10_9_universal2.whl", hash = "sha256:5bb28c636d87e840583ee3adeb78172efc47c8b26127267f54a9c0ec251d41a9"},
     {file = "MarkupSafe-2.0.1-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:be98f628055368795d818ebf93da628541e10b75b41c559fdf36d104c5787066"},
     {file = "MarkupSafe-2.0.1-cp38-cp38-manylinux1_i686.whl", hash = "sha256:1d609f577dc6e1aa17d746f8bd3c31aa4d258f4070d61b2aa5c4166c1539de35"},
     {file = "MarkupSafe-2.0.1-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:7d91275b0245b1da4d4cfa07e0faedd5b0812efc15b702576d103293e252af1b"},
     {file = "MarkupSafe-2.0.1-cp38-cp38-manylinux2010_i686.whl", hash = "sha256:01a9b8ea66f1658938f65b93a85ebe8bc016e6769611be228d797c9d998dd298"},
     {file = "MarkupSafe-2.0.1-cp38-cp38-manylinux2010_x86_64.whl", hash = "sha256:47ab1e7b91c098ab893b828deafa1203de86d0bc6ab587b160f78fe6c4011f75"},
     {file = "MarkupSafe-2.0.1-cp38-cp38-manylinux2014_aarch64.whl", hash = "sha256:97383d78eb34da7e1fa37dd273c20ad4320929af65d156e35a5e2d89566d9dfb"},
+    {file = "MarkupSafe-2.0.1-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:6fcf051089389abe060c9cd7caa212c707e58153afa2c649f00346ce6d260f1b"},
+    {file = "MarkupSafe-2.0.1-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:5855f8438a7d1d458206a2466bf82b0f104a3724bf96a1c781ab731e4201731a"},
+    {file = "MarkupSafe-2.0.1-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:3dd007d54ee88b46be476e293f48c85048603f5f516008bee124ddd891398ed6"},
     {file = "MarkupSafe-2.0.1-cp38-cp38-win32.whl", hash = "sha256:023cb26ec21ece8dc3907c0e8320058b2e0cb3c55cf9564da612bc325bed5e64"},
     {file = "MarkupSafe-2.0.1-cp38-cp38-win_amd64.whl", hash = "sha256:984d76483eb32f1bcb536dc27e4ad56bba4baa70be32fa87152832cdd9db0833"},
     {file = "MarkupSafe-2.0.1-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:2ef54abee730b502252bcdf31b10dacb0a416229b72c18b19e24a4509f273d26"},
@@ -2880,6 +2920,9 @@ markupsafe = [
     {file = "MarkupSafe-2.0.1-cp39-cp39-manylinux2010_i686.whl", hash = "sha256:4efca8f86c54b22348a5467704e3fec767b2db12fc39c6d963168ab1d3fc9135"},
     {file = "MarkupSafe-2.0.1-cp39-cp39-manylinux2010_x86_64.whl", hash = "sha256:ab3ef638ace319fa26553db0624c4699e31a28bb2a835c5faca8f8acf6a5a902"},
     {file = "MarkupSafe-2.0.1-cp39-cp39-manylinux2014_aarch64.whl", hash = "sha256:f8ba0e8349a38d3001fae7eadded3f6606f0da5d748ee53cc1dab1d6527b9509"},
+    {file = "MarkupSafe-2.0.1-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c47adbc92fc1bb2b3274c4b3a43ae0e4573d9fbff4f54cd484555edbf030baf1"},
+    {file = "MarkupSafe-2.0.1-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:37205cac2a79194e3750b0af2a5720d95f786a55ce7df90c3af697bfa100eaac"},
+    {file = "MarkupSafe-2.0.1-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:1f2ade76b9903f39aa442b4aadd2177decb66525062db244b35d71d0ee8599b6"},
     {file = "MarkupSafe-2.0.1-cp39-cp39-win32.whl", hash = "sha256:10f82115e21dc0dfec9ab5c0223652f7197feb168c940f3ef61563fc2d6beb74"},
     {file = "MarkupSafe-2.0.1-cp39-cp39-win_amd64.whl", hash = "sha256:693ce3f9e70a6cf7d2fb9e6c9d8b204b6b39897a2c4a1aa65728d5ac97dcc1d8"},
     {file = "MarkupSafe-2.0.1.tar.gz", hash = "sha256:594c67807fb16238b30c44bdf74f36c02cdf22d1c8cda91ef8a0ed8dabf5620a"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -74,6 +74,7 @@ ipython = "*"
 factory-boy = "*"
 colorlog = "*"
 drf-writable-nested = "*"
+graphene-file-upload = "^1.3.0"
 
 [tool.poetry.dev-dependencies]
 pytest-profiling = "*"

--- a/utils/graphene/mutation.py
+++ b/utils/graphene/mutation.py
@@ -10,6 +10,7 @@ from graphene_django.rest_framework.serializer_converter import (
     get_graphene_type_from_serializer_field,
 )
 from rest_framework import serializers
+from graphene_file_upload.scalars import Upload
 
 from utils.graphene.error_types import mutation_is_not_valid
 # from utils.common import to_camelcase
@@ -65,6 +66,8 @@ def convert_serializer_field(field, is_input=True, convert_choices_to_enum=True)
 
     if isinstance(field, serializers.ChoiceField) and not convert_choices_to_enum:
         graphql_type = graphene.String
+    elif isinstance(field, serializers.FileField):
+        graphql_type = Upload
     else:
         graphql_type = get_graphene_type_from_serializer_field(field)
 


### PR DESCRIPTION
Addresses https://zube.io/deep/deep/c/3901

## Changes

* Install django-graphene-file-upload
* Added file upload feature in AF preview_image

## This PR doesn't introduce any:

- [x] temporary files, auto-generated files or secret keys
- [x] n+1 queries
- [x] flake8 issues
- [x] `print`
- [x] typos
- [x] unwanted comments

## This PR contains valid:

- [x] tests
- [ ] permission checks (tests here too)
- [ ] translations
