### PR TITLE
Rename project join_request delete mutation

### DIFF
--- a/apps/project/mutation.py
+++ b/apps/project/mutation.py
@@ -45,7 +45,7 @@ class ProjectAcceptReject(PsGrapheneMutation):
     permissions = [PP.Permission.UPDATE_PROJECT]
 
 
-class DeleteProjectJoinRequest(graphene.Mutation):
+class ProjectJoinRequestDelete(graphene.Mutation):
     class Arguments:
         project_id = graphene.ID(required=True)
 
@@ -60,7 +60,7 @@ class DeleteProjectJoinRequest(graphene.Mutation):
                                                       status=ProjectJoinRequest.Status.PENDING,
                                                       project=project_id)
         except ProjectJoinRequest.DoesNotExist:
-            return DeleteProjectJoinRequest(errors=[
+            return ProjectJoinRequestDelete(errors=[
                 dict(
                     field='nonFieldErrors',
                     messages=gettext('ProjectJoinRequest does not exist for project(id:%s)' % project_id)
@@ -68,7 +68,7 @@ class DeleteProjectJoinRequest(graphene.Mutation):
             ], ok=False)
         instance.delete()
         instance.id = id
-        return DeleteProjectJoinRequest(result=instance, errors=None, ok=True)
+        return ProjectJoinRequestDelete(result=instance, errors=None, ok=True)
 
 
 class CreateProjectJoin(graphene.Mutation):
@@ -115,6 +115,6 @@ class ProjectMutationType(
 
 class Mutation(object):
     join_project = CreateProjectJoin.Field()
-    delete_project_join = DeleteProjectJoinRequest.Field()
+    project_join_request_delete = ProjectJoinRequestDelete.Field()
     project = DjangoObjectField(ProjectMutationType)
     # TODO: For project mutation make sure AF permission is checked when using. (Public and Private logics)

--- a/apps/project/tests/test_schemas.py
+++ b/apps/project/tests/test_schemas.py
@@ -451,9 +451,9 @@ class TestProjectJoinMutation(GraphQLTestCase):
 
 class TestProjectJoinDeleteMutation(GraphQLTestCase):
     def setUp(self):
-        self.project_join_delete_mutation = '''
+        self.project_join_request_delete_mutation = '''
             mutation Mutation($projectId: ID!) {
-              deleteProjectJoin(projectId: $projectId) {
+              projectJoinRequestDelete(projectId: $projectId) {
                 ok
                 errors
                 result {
@@ -484,7 +484,7 @@ class TestProjectJoinDeleteMutation(GraphQLTestCase):
         old_join_request_count = join_request_qs.count()
 
         self.force_login(user)
-        self.query_check(self.project_join_delete_mutation, variables={'projectId': project.id}, okay=True)
+        self.query_check(self.project_join_request_delete_mutation, variables={'projectId': project.id}, okay=True)
         self.assertEqual(join_request_qs.count(), old_join_request_count - 1)
 
 


### PR DESCRIPTION

## Changes
- rename mutation name for join_request delete from `delete_project_join` to `project_join_request_delete`

Mention related users here if any.

## This PR doesn't introduce any:

- [x] temporary files, auto-generated files or secret keys
- [x] n+1 queries
- [x] flake8 issues
- [x] `print`
- [x] typos
- [x] unwanted comments

## This PR contains valid:

- [ ] tests
- [ ] permission checks (tests here too)
- [ ] translations
