### PR TITLE
Feature/iframe allow for project viz

### DIFF
--- a/deep/tests/test_views.py
+++ b/deep/tests/test_views.py
@@ -1,5 +1,11 @@
+import uuid
+
 from django.test import TestCase, Client
+from django.urls import reverse
+
 from deep.views import FrontendView
+from project.models import ProjectStats
+from project.factories import ProjectFactory
 
 
 class TestIndexView(TestCase):
@@ -9,3 +15,22 @@ class TestIndexView(TestCase):
         response = client.get('/')
         self.assertEqual(response.resolver_match.func.__name__,
                          FrontendView.as_view().__name__)
+
+
+class ProjectVizView(TestCase):
+    def test_x_frame_headers(self):
+        client = Client()
+        url = reverse('server-frontend')
+        response = client.get(url)
+        # There should be x-frame-options by default in views
+        assert 'X-Frame-Options' in response.headers
+
+        project = ProjectFactory.create()
+        stat = ProjectStats.objects.create(project=project, token=uuid.uuid4())
+        url = reverse('project-stat-viz-public', kwargs={
+            'project_stat_id': stat.id,
+            'token': stat.token,
+        })
+        response = client.get(url)
+        # There should not be x-frame-options in specific views like project-stat-viz-public
+        assert 'X-Frame-Options' not in response.headers

--- a/deep/urls.py
+++ b/deep/urls.py
@@ -16,7 +16,6 @@ from drf_yasg import openapi
 from django_otp.admin import OTPAdminSite
 
 from . import converters
-from deep.views import CustomGraphQLView
 
 # import autofixture
 
@@ -148,16 +147,17 @@ from export.views import (
     ExportViewSet,
 )
 from deep.views import (
-    get_frontend_url,
+    AccountActivate,
     Api_404View,
     CombinedView,
+    CustomGraphQLView,
+    EntryCommentEmail,
+    EntryReviewCommentEmail,
     FrontendView,
     PasswordReset,
     ProjectJoinRequest,
     ProjectPublicVizView,
-    EntryCommentEmail,
-    EntryReviewCommentEmail,
-    AccountActivate,
+    get_frontend_url,
 )
 from organization.views import (
     OrganizationViewSet,
@@ -388,7 +388,7 @@ if not settings.DEBUG:
     admin.site.__class__ = OTPAdminSite
 
 urlpatterns = [
-    re_path(r'^$', FrontendView.as_view()),
+    re_path(r'^$', FrontendView.as_view(), name='server-frontend'),
     re_path(r'^admin/', admin.site.urls),
 
     re_path(r'^api-docs(?P<format>\.json|\.yaml)$',

--- a/deep/views.py
+++ b/deep/views.py
@@ -1,11 +1,12 @@
 from rest_framework.exceptions import NotFound, PermissionDenied
-from django.core.exceptions import PermissionDenied as DjPermissionDenied
 from rest_framework import (
     views,
     status,
     response,
 )
 
+from django.core.exceptions import PermissionDenied as DjPermissionDenied
+from django.views.decorators.clickjacking import xframe_options_exempt
 from django.http import JsonResponse
 from django.urls import resolve
 from django.views.generic import View
@@ -75,6 +76,7 @@ class ProjectPublicVizView(View):
     """
     View for public viz view without user authentication
     """
+    @xframe_options_exempt
     def get(self, request, project_stat_id, token):
         from project.views import _get_viz_data
 


### PR DESCRIPTION

Addresses Project-Viz public not accessible in Iframe.

## Changes

* All iframe for Project-Viz public url.

Mention related users here if any.

## This PR doesn't introduce any:

- [x] temporary files, auto-generated files or secret keys
- [x] n+1 queries
- [x] flake8 issues
- [x] `print`
- [x] typos
- [x] unwanted comments

## This PR contains valid:

- [x] tests
- [ ] permission checks (tests here too)
- [ ] translations
