### PR TITLE
Update lead schema fields

### DIFF
--- a/apps/analysis_framework/serializers.py
+++ b/apps/analysis_framework/serializers.py
@@ -300,6 +300,7 @@ class AfWidgetLimit():
 
 class WidgetGqlSerializer(TempClientIdMixin, serializers.ModelSerializer):
     id = IntegerIDField(required=False)
+    key = serializers.CharField(required=True)
 
     class Meta:
         model = Widget

--- a/apps/lead/dataloaders.py
+++ b/apps/lead/dataloaders.py
@@ -18,7 +18,7 @@ class LeadPreviewLoader(DataLoaderWithContext):
         return Promise.resolve([_map.get(key) for key in keys])
 
 
-class ControlledStatLoader(DataLoaderWithContext):
+class EntriesCountLoader(DataLoaderWithContext):
     def batch_load_fn(self, keys):
         stat_qs = Entry.objects\
             .filter(lead__in=keys)\
@@ -40,5 +40,5 @@ class DataLoaders(WithContextMixin):
         return LeadPreviewLoader(context=self.context)
 
     @cached_property
-    def controlled_stat(self):
-        return ControlledStatLoader(context=self.context)
+    def entries_counts(self):
+        return EntriesCountLoader(context=self.context)

--- a/apps/lead/schema.py
+++ b/apps/lead/schema.py
@@ -117,9 +117,9 @@ class EmmKeyRiskFactorType(graphene.ObjectType):
     emm_risk_factors = graphene.String()
 
 
-class ControlledStatType(graphene.ObjectType):
-    total_count = graphene.Int()
-    controlled_count = graphene.Int()
+class EntriesCountType(graphene.ObjectType):
+    total = graphene.Int()
+    controlled = graphene.Int()
 
 
 class LeadGroupType(DjangoObjectType):
@@ -162,7 +162,7 @@ class LeadType(ClientIdMixin, DjangoObjectType):
     lead_preview = graphene.Field(LeadPreviewType)
     source = graphene.Field(OrganizationType)
     authors = DjangoListField(OrganizationType)
-    controlled_stat = graphene.Field(ControlledStatType)
+    entries_counts = graphene.Field(EntriesCountType)
     assignee = graphene.Field(UserType)
     lead_group = graphene.Field(LeadGroupType)
     # EMM Fields
@@ -182,9 +182,9 @@ class LeadType(ClientIdMixin, DjangoObjectType):
         return info.context.dl.lead.lead_preview.load(root.pk)
 
     @staticmethod
-    def resolve_controlled_stat(root, info, **kwargs):
+    def resolve_entries_counts(root, info, **kwargs):
         # TODO: Use entry filter here as well
-        return info.context.dl.lead.controlled_stat.load(root.pk)
+        return info.context.dl.lead.entries_counts.load(root.pk)
 
 
 class LeadDetailType(LeadType):

--- a/apps/lead/tests/test_schemas.py
+++ b/apps/lead/tests/test_schemas.py
@@ -372,7 +372,8 @@ class TestLeadQuerySchema(GraphQLTestCase):
             }
         '''
 
-        project = ProjectFactory.create()
+        af = AnalysisFrameworkFactory.create()
+        project = ProjectFactory.create(analysis_framework=af)
         org_type = OrganizationTypeFactory.create()
         org1 = OrganizationFactory.create(organization_type=org_type)
         org2 = OrganizationFactory.create(organization_type=org_type, parent=org1)
@@ -383,6 +384,12 @@ class TestLeadQuerySchema(GraphQLTestCase):
         # Create lead
         lead1 = LeadFactory.create(project=project, source=org1)
         lead2 = LeadFactory.create(project=project, source=org2, authors=[org1, org3])
+        lead3 = LeadFactory.create(project=project)
+
+        # Some entries for entriesCounts
+        EntryFactory.create_batch(2, lead=lead1, controlled=True)
+        EntryFactory.create_batch(5, lead=lead1)
+        EntryFactory.create_batch(10, lead=lead2)
 
         # -- With login
         self.force_login(user)
@@ -392,8 +399,8 @@ class TestLeadQuerySchema(GraphQLTestCase):
         content = self.query_check(query, variables={'id': project.id})
         results = content['data']['project']['leads']['results']
         # Count check
-        self.assertEqual(content['data']['project']['leads']['totalCount'], 2, content)
-        self.assertListIds(results, [lead1, lead2], content)
+        self.assertEqual(content['data']['project']['leads']['totalCount'], 3, content)
+        self.assertListIds(results, [lead1, lead2, lead3], content)
         self.assertEqual(len(results[0]['authors']), 0, content)
         # Source check
         self.assertIdEqual(results[0]['source']['id'], org1.id, content)
@@ -402,6 +409,14 @@ class TestLeadQuerySchema(GraphQLTestCase):
         # Authors check
         self.assertListIds(results[1]['authors'], [org1, org3], content)
         self.assertIdEqual(results[1]['source']['mergedAs']['id'], org1.id, content)
+        # Entries Count check
+        for index, (total_count, controlled_count) in enumerate([
+            [7, 2],
+            [10, 0],
+            [0, 0],
+        ]):
+            self.assertEqual(results[index]['entriesCounts']['total'], total_count, content)
+            self.assertEqual(results[index]['entriesCounts']['controlled'], controlled_count, content)
 
     def test_lead_options_query(self):
         """

--- a/apps/lead/tests/test_schemas.py
+++ b/apps/lead/tests/test_schemas.py
@@ -334,9 +334,9 @@ class TestLeadQuerySchema(GraphQLTestCase):
                     title
                     publishedOn
                     priority
-                    controlledStat {
-                      totalCount
-                      controlledCount
+                    entriesCounts {
+                      total
+                      controlled
                     }
                     authors {
                       id

--- a/schema.graphql
+++ b/schema.graphql
@@ -215,11 +215,6 @@ type ChangeUserPassword {
   ok: Boolean
 }
 
-type ControlledStatType {
-  totalCount: Int
-  controlledCount: Int
-}
-
 type CreateAnalysisFramework {
   errors: [GenericScalar!]
   ok: Boolean
@@ -320,6 +315,11 @@ type EmmKeyRiskFactorType {
 
 type EmmKeyWordType {
   emmKeywords: String
+}
+
+type EntriesCountType {
+  total: Int
+  controlled: Int
 }
 
 enum EntryFilterCommentStatusEnum {
@@ -559,7 +559,7 @@ type LeadDetailType {
   leadPreview: LeadPreviewType
   source: OrganizationType
   authors: [OrganizationType!]
-  controlledStat: ControlledStatType
+  entriesCounts: EntriesCountType
   emmEntities: [EmmEntityType!]
   emmTriggers: [LeadEmmTriggerType!]
   entries: [EntryType!]
@@ -727,7 +727,7 @@ type LeadType {
   leadPreview: LeadPreviewType
   source: OrganizationType
   authors: [OrganizationType!]
-  controlledStat: ControlledStatType
+  entriesCounts: EntriesCountType
   emmEntities: [EmmEntityType!]
   emmTriggers: [LeadEmmTriggerType!]
 }
@@ -1292,7 +1292,7 @@ enum WidgetFilterTypeEnum {
 
 input WidgetGqlInputType {
   id: ID
-  key: String
+  key: String!
   widgetId: WidgetWidgetTypeEnum!
   title: String!
   properties: GenericScalar


### PR DESCRIPTION
Addresses
- #985


## Changes

- Change ControlledStat -> EntriesCount
- Make widget key required field

Mention related users here if any.
@samshara, Please check the below mapping and changes in schema from the check below `graphql-inspector`.
```
entriesCount (number of entries in each source) -> entriesCount.total
pageCount (number of pages) -> leadPreview.pageCount
```

## This PR doesn't introduce any:

- [x] temporary files, auto-generated files or secret keys
- [x] n+1 queries
- [x] flake8 issues
- [x] `print`
- [x] typos
- [x] unwanted comments

## This PR contains valid:

- [x] tests
- [ ] permission checks (tests here too)
- [ ] translations