### PR TITLE
Feature/entry review graphql

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,6 +56,15 @@ jobs:
             exit 1;
           }
 
+      - name: 🕮 Validate if there are no pending django migrations.
+        env:
+          DOCKER_IMAGE_SERVER: ${{ steps.prep.outputs.tagged_image }}
+        run: |
+          docker-compose exec server bash -c 'python3 manage.py makemigrations --check --dry-run' || {
+            echo 'There are some changes to be reflected in the migration. Make sure to run makemigrations';
+            exit 1;
+          }
+
       - name: 🤞 Run Test 🧪 & Publish coverage to code climate
         uses: paambaati/codeclimate-action@v2.7.5
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,7 +60,7 @@ jobs:
         env:
           DOCKER_IMAGE_SERVER: ${{ steps.prep.outputs.tagged_image }}
         run: |
-          docker-compose exec server bash -c 'python3 manage.py makemigrations --check --dry-run' || {
+          docker-compose -f gh-docker-compose.yml run --rm server python3 manage.py makemigrations --check --dry-run || {
             echo 'There are some changes to be reflected in the migration. Make sure to run makemigrations';
             exit 1;
           }

--- a/apps/entry/migrations/0031_entry-migrate-verify-to-review-comment.py
+++ b/apps/entry/migrations/0031_entry-migrate-verify-to-review-comment.py
@@ -3,7 +3,7 @@
 from django.db import migrations, models
 
 from deep.managers import BulkCreateManager
-from quality_assurance.models import CommentType
+from quality_assurance.models import EntryReviewComment
 
 
 # NOTE: Using _ here as importlib doesn't find private functions
@@ -20,7 +20,10 @@ def migrate_entry_controlled_to_review_comment_(Entry, EntryReviewComment):
             EntryReviewComment(
                 entry_id=entry.id,
                 created_by_id=entry.controlled_changed_by_id,
-                comment_type=CommentType.VERIFY if entry.controlled else CommentType.UNVERIFY,
+                comment_type=(
+                    EntryReviewComment.CommentType.VERIFY if entry.controlled
+                    else EntryReviewComment.CommentType.UNVERIFY
+                ),
             )
         )
         verified_by_users_id = [u.id for u in entry.verified_by.all()]

--- a/apps/entry/schema.py
+++ b/apps/entry/schema.py
@@ -106,6 +106,7 @@ class EntryType(ClientIdMixin, DjangoObjectType):
     project_labels = graphene.List(graphene.NonNull(EntryGroupLabelType))
     verified_by = DjangoListField(UserType)
     review_comments = graphene.List(graphene.NonNull(EntryReviewCommentType))
+    review_comments_count = graphene.Int(required=True)
 
     # project_labels TODO:
     # tabular_field TODO:
@@ -113,6 +114,10 @@ class EntryType(ClientIdMixin, DjangoObjectType):
     @staticmethod
     def get_custom_queryset(queryset, info, **kwargs):
         return get_entry_qs(info)
+
+    @staticmethod
+    def resolve_review_comments_count(root, info, **kwargs):
+        return root.entryreviewcomment_set.count()
 
     @staticmethod
     def resolve_project_labels(root, info, **kwargs):

--- a/apps/entry/tests/test_migrations.py
+++ b/apps/entry/tests/test_migrations.py
@@ -3,7 +3,7 @@ import importlib
 from deep.tests import TestCase
 
 from entry.models import Entry
-from quality_assurance.models import EntryReviewComment, CommentType
+from quality_assurance.models import EntryReviewComment
 
 
 class TestCustomMigrationsLogic(TestCase):
@@ -49,13 +49,17 @@ class TestCustomMigrationsLogic(TestCase):
         assert EntryReviewComment.objects.count() == 3
         # Related review comment are created by user last action on entry.
         assert set(EntryReviewComment.objects.values_list('created_by_id', flat=True)) == set([user1.pk, user2.pk, user3.pk])
-        assert EntryReviewComment.objects.filter(comment_type=CommentType.VERIFY).count() == 2
-        assert EntryReviewComment.objects.filter(comment_type=CommentType.UNVERIFY).count() == 1
+        assert EntryReviewComment.objects.filter(comment_type=EntryReviewComment.CommentType.VERIFY).count() == 2
+        assert EntryReviewComment.objects.filter(comment_type=EntryReviewComment.CommentType.UNVERIFY).count() == 1
         assert set(
-            EntryReviewComment.objects.filter(comment_type=CommentType.VERIFY).values_list('created_by_id', flat=True)
+            EntryReviewComment.objects.filter(
+                comment_type=EntryReviewComment.CommentType.VERIFY,
+            ).values_list('created_by_id', flat=True)
         ) == set([user1.pk, user2.pk])
         assert set(
-            EntryReviewComment.objects.filter(comment_type=CommentType.UNVERIFY).values_list('created_by_id', flat=True)
+            EntryReviewComment.objects.filter(
+                comment_type=EntryReviewComment.CommentType.UNVERIFY,
+            ).values_list('created_by_id', flat=True)
         ) == set([user3.pk])
         # All controlled, controlled_changed_by should be reset.
         assert Entry.objects.filter(controlled=True).count() == 0

--- a/apps/lead/serializers.py
+++ b/apps/lead/serializers.py
@@ -1,5 +1,4 @@
 from django.shortcuts import get_object_or_404
-from django.utils.functional import cached_property
 from django.db import transaction
 from drf_dynamic_fields import DynamicFieldsMixin
 from rest_framework import serializers
@@ -12,6 +11,7 @@ from deep.serializers import (
     IdListField,
     StringListField,
     WriteOnlyOnCreateSerializerMixin,
+    ProjectPropertySerializerMixin,
 )
 from organization.serializers import SimpleOrganizationSerializer
 from user.serializers import SimpleUserSerializer
@@ -392,7 +392,7 @@ class LeadOptionsSerializer(serializers.Serializer):
 
 
 # ------------------- Graphql Serializers ----------------------------------------
-class LeadGqSerializer(TempClientIdMixin, UserResourceSerializer):
+class LeadGqSerializer(ProjectPropertySerializerMixin, TempClientIdMixin, UserResourceSerializer):
     """
     Lead Model Serializer for Graphql (NOTE: Don't use this on DRF Views)
     """
@@ -426,14 +426,6 @@ class LeadGqSerializer(TempClientIdMixin, UserResourceSerializer):
             'emm_entities',
             'client_id',  # From TempClientIdMixin
         )
-
-    @cached_property
-    def project(self):
-        project = self.context['request'].active_project
-        # This is a rare case, just to make sure this is validated
-        if self.instance and self.instance.project != project:
-            raise serializers.ValidationError('Invalid access')
-        return project
 
     def validate_attachment(self, attachment):
         if attachment and attachment.created_by != self.context['request'].user:

--- a/apps/notification/tasks.py
+++ b/apps/notification/tasks.py
@@ -5,7 +5,7 @@ from entry.models import EntryComment
 from user.models import User, Profile
 from user.utils import send_mail_to_user
 
-from quality_assurance.models import EntryReviewComment, CommentType
+from quality_assurance.models import EntryReviewComment
 
 from .models import Notification
 
@@ -37,7 +37,7 @@ def send_entry_review_comment_email(user_id, comment_id, notification_type):
         user, Profile.E_EMAIL_COMMENT,
         context={
             'Notification': Notification,
-            'CommentType': CommentType,
+            'CommentType': EntryReviewComment.CommentType,
             'notification_type': notification_type,
             'comment': comment,
         },

--- a/apps/project/mutation.py
+++ b/apps/project/mutation.py
@@ -17,6 +17,7 @@ from deep.permissions import ProjectPermissions as PP
 
 from lead.mutation import Mutation as LeadMutation
 from entry.mutation import Mutation as EntryMutation
+from quality_assurance.mutation import Mutation as QualityAssuranceMutation
 
 from .models import (
     Project,
@@ -179,6 +180,7 @@ class BulkUpdateProjectUserGroupMembership(PsBulkGrapheneMutation):
 class ProjectMutationType(
     LeadMutation,
     EntryMutation,
+    QualityAssuranceMutation,
     DjangoObjectType
 ):
     """

--- a/apps/project/schema.py
+++ b/apps/project/schema.py
@@ -21,6 +21,7 @@ from entry.schema import Query as EntryQuery
 from export.schema import Query as ExportQuery
 from geo.schema import RegionType, ProjectScopeQuery as GeoQuery
 from quality_assurance.schema import Query as QualityAssuranceQuery
+
 from lead.models import Lead
 from entry.models import Entry
 

--- a/apps/quality_assurance/enums.py
+++ b/apps/quality_assurance/enums.py
@@ -3,13 +3,13 @@ from utils.graphene.enums import (
     get_enum_name_from_django_field,
 )
 
-from quality_assurance.models import CommentType, BaseReviewComment
+from quality_assurance.models import EntryReviewComment
 
-ReviewCommentTypeEnum = convert_enum_to_graphene_enum(CommentType, name='ReviewCommentTypeEnum')
+EntryReviewCommentTypeEnum = convert_enum_to_graphene_enum(EntryReviewComment.CommentType, name='EntryReviewCommentTypeEnum')
 
 enum_map = {
     get_enum_name_from_django_field(field): enum
     for field, enum in (
-        (BaseReviewComment.comment_type, ReviewCommentTypeEnum),
+        (EntryReviewComment.comment_type, EntryReviewCommentTypeEnum),
     )
 }

--- a/apps/quality_assurance/migrations/0001_initial.py
+++ b/apps/quality_assurance/migrations/0001_initial.py
@@ -21,7 +21,7 @@ class Migration(migrations.Migration):
             name='EntryReviewComment',
             fields=[
                 ('id', models.AutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
-                ('comment_type', django_enumfield.db.fields.EnumField(default=0, enum=quality_assurance.models.CommentType)),
+                ('comment_type', django.db.models.IntegerField(default=0, choices=[(0, 'Comment'), (1, 'Verify'), (2, 'Unverify'), (3, 'Control'), (4, 'UnControl')])),
                 ('created_by', models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, related_name='entryreviewcomment_created', to=settings.AUTH_USER_MODEL)),
                 ('entry', models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, to='entry.Entry')),
                 ('mentioned_users', models.ManyToManyField(blank=True, to=settings.AUTH_USER_MODEL)),

--- a/apps/quality_assurance/mutation.py
+++ b/apps/quality_assurance/mutation.py
@@ -1,0 +1,49 @@
+import graphene
+
+from utils.graphene.mutation import (
+    generate_input_type_for_serializer,
+    PsGrapheneMutation,
+)
+from deep.permissions import ProjectPermissions as PP
+
+from .models import EntryReviewComment
+from .schema import EntryReviewCommentDetailType
+from .serializers import (
+    EntryReviewCommentGqlSerializer as EntryReviewCommentSerializer,
+)
+
+
+EntryReviewCommentInputType = generate_input_type_for_serializer(
+    'EntryReviewCommentInputType',
+    serializer_class=EntryReviewCommentSerializer,
+)
+
+
+class EntryReviewCommentMutationMixin():
+    @classmethod
+    def filter_queryset(cls, qs, info):
+        return qs.filter(created_by=info.context.user)
+
+
+class CreateEntryReviewComment(EntryReviewCommentMutationMixin, PsGrapheneMutation):
+    class Arguments:
+        data = EntryReviewCommentInputType(required=True)
+    model = EntryReviewComment
+    serializer_class = EntryReviewCommentSerializer
+    result = graphene.Field(EntryReviewCommentDetailType)
+    permissions = [PP.Permission.CREATE_ENTRY, PP.Permission.UPDATE_ENTRY]
+
+
+class UpdateEntryReviewComment(EntryReviewCommentMutationMixin, PsGrapheneMutation):
+    class Arguments:
+        data = EntryReviewCommentInputType(required=True)
+        id = graphene.ID(required=True)
+    model = EntryReviewComment
+    serializer_class = EntryReviewCommentSerializer
+    result = graphene.Field(EntryReviewCommentDetailType)
+    permissions = [PP.Permission.CREATE_ENTRY, PP.Permission.UPDATE_ENTRY]
+
+
+class Mutation():
+    entry_review_comment_create = CreateEntryReviewComment.Field()
+    entry_review_comment_update = UpdateEntryReviewComment.Field()

--- a/apps/quality_assurance/schema.py
+++ b/apps/quality_assurance/schema.py
@@ -8,7 +8,7 @@ from deep.permissions import ProjectPermissions as PP
 from lead.models import Lead
 
 from quality_assurance.models import EntryReviewComment, EntryReviewCommentText
-from .enums import ReviewCommentTypeEnum
+from .enums import EntryReviewCommentTypeEnum
 
 
 def get_entry_comment_qs(info):
@@ -30,7 +30,7 @@ def get_entry_comment_qs(info):
 class EntryReviewCommentTextType(DjangoObjectType):
     class Meta:
         model = EntryReviewCommentText
-        field = (
+        fields = (
             'id',
             'created_at',
             'text',
@@ -43,15 +43,15 @@ class EntryReviewCommentType(DjangoObjectType):
         skip_registry = True
         fields = (
             'id',
-            'entry',
             'created_by',
             'created_at',
             'mentioned_users'
         )
 
-    comment_type = graphene.Field(ReviewCommentTypeEnum, required=True)
+    comment_type = graphene.Field(EntryReviewCommentTypeEnum, required=True)
     comment_type_display = EnumDescription(source='get_comment_type_display', required=True)
     text = graphene.String()
+    entry = graphene.ID(source='entry_id', required=True)
 
 
 class EntryReviewCommentDetailType(EntryReviewCommentType):

--- a/apps/quality_assurance/serializers.py
+++ b/apps/quality_assurance/serializers.py
@@ -1,7 +1,10 @@
+from django.utils.functional import cached_property
 from django.db import transaction
 from rest_framework import serializers
 
 from deep.middleware import get_current_user
+from deep.permissions import ProjectPermissions as PP
+from deep.serializers import ProjectPropertySerializerMixin
 from user.serializers import EntryCommentUserSerializer, UserNotificationSerializer
 from project.serializers import ProjectNotificationSerializer
 
@@ -13,7 +16,6 @@ from notification.tasks import send_notifications_for_comment
 from .models import (
     EntryReviewComment,
     EntryReviewCommentText,
-    CommentType,
 )
 
 
@@ -46,7 +48,7 @@ class EntryReviewCommentSerializer(serializers.ModelSerializer):
         if self.instance and self.instance.comment_type:  # No validation needed for edit
             return self.instance.comment_type
 
-        if comment_type == CommentType.COMMENT:
+        if comment_type == EntryReviewComment.CommentType.COMMENT:
             return comment_type  # No additional validation/action required
 
         entry = self._get_entry()
@@ -54,7 +56,10 @@ class EntryReviewCommentSerializer(serializers.ModelSerializer):
         verified_by_qs = Entry.verified_by.through.objects.filter(entry=entry, user=current_user)
 
         if (
-            comment_type in [CommentType.CONTROL, CommentType.UNCONTROL] and
+            comment_type in [
+                EntryReviewComment.CommentType.CONTROL,
+                EntryReviewComment.CommentType.UNCONTROL,
+            ] and
             not ProjectMembership.objects.filter(
                 project=entry.project,
                 member=self.context['request'].user,
@@ -65,19 +70,19 @@ class EntryReviewCommentSerializer(serializers.ModelSerializer):
                 'comment_type': 'Controlled/UnControlled comment are only allowd by QA',
             })
 
-        if comment_type == CommentType.VERIFY:
+        if comment_type == EntryReviewComment.CommentType.VERIFY:
             if verified_by_qs.exists():
                 raise serializers.ValidationError({'comment_type': 'Already verified'})
             entry.verified_by.add(current_user)
-        elif comment_type == CommentType.UNVERIFY:
+        elif comment_type == EntryReviewComment.CommentType.UNVERIFY:
             if not verified_by_qs.exists():
                 raise serializers.ValidationError({'comment_type': 'Need to be verified first'})
             entry.verified_by.remove(current_user)
-        elif comment_type == CommentType.CONTROL:
+        elif comment_type == EntryReviewComment.CommentType.CONTROL:
             if entry.controlled:
                 raise serializers.ValidationError({'comment_type': 'Already controlled'})
             entry.control(current_user)
-        elif comment_type == CommentType.UNCONTROL:
+        elif comment_type == EntryReviewComment.CommentType.UNCONTROL:
             if not entry.controlled:
                 raise serializers.ValidationError({'comment_type': 'Need to be controlled first'})
             entry.control(current_user, controlled=False)
@@ -110,9 +115,13 @@ class EntryReviewCommentSerializer(serializers.ModelSerializer):
         Comment Middleware save logic
         """
         text = validated_data.pop('text', '').strip()
-        comment_type = validated_data.get('comment_type', CommentType.__default__)
+        comment_type = validated_data.get('comment_type', EntryReviewComment.CommentType.COMMENT)
         # Make sure to check text required
-        if not text and comment_type in [CommentType.COMMENT, CommentType.UNVERIFY, CommentType.UNCONTROL]:
+        if not text and comment_type in [
+            EntryReviewComment.CommentType.COMMENT,
+            EntryReviewComment.CommentType.UNVERIFY,
+            EntryReviewComment.CommentType.UNCONTROL,
+        ]:
             raise serializers.ValidationError({'text': 'Text is required'})
 
         current_text = instance and instance.text
@@ -166,3 +175,163 @@ class EntryReviewCommentNotificationSerializer(serializers.ModelSerializer):
 
 class VerifiedBySerializer(EntryCommentUserSerializer):
     pass
+
+
+# ------------- Graphql Serializer ------------------------------
+class EntryReviewCommentGqlSerializer(ProjectPropertySerializerMixin, serializers.ModelSerializer):
+    text = serializers.CharField(write_only=True, required=False)
+
+    class Meta:
+        model = EntryReviewComment
+        fields = (
+            'entry',
+            'comment_type',
+            'text',
+            'mentioned_users',
+        )
+
+    project_property_attribute = 'entry'
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.pending_commits = []
+
+    @cached_property
+    def entry(self):
+        entry = (
+            (self.instance and self.instance.entry) or
+            Entry.objects.filter(id=self.initial_data.get('entry')).first()
+        )
+        if entry is None:
+            raise serializers.ValidationError('Entry is not defined. Invalid request.')
+        if entry.project != self.project:
+            raise serializers.ValidationError("Entry from another project isn't allowed!!")
+        return entry
+
+    def validate_entry(self, entry):
+        if self.instance and self.instance.entry != entry:
+            raise serializers.ValidationError('Changing comment entry is not allowed.')
+        return entry
+
+    def validate_comment_type(self, comment_type):
+        # No validation needed for edit since we don't allow changing it
+        if self.instance:
+            if self.instance.comment_type != comment_type:
+                raise serializers.ValidationError('Changing comment type is not allowed')
+            return comment_type
+
+        if comment_type == EntryReviewComment.CommentType.COMMENT:
+            return comment_type  # No additional validation/action required
+
+        current_user = self.context['request'].user
+        verified_by_qs = Entry.verified_by.through.objects.filter(entry=self.entry, user=current_user)
+
+        if (
+            comment_type in [
+                EntryReviewComment.CommentType.CONTROL,
+                EntryReviewComment.CommentType.UNCONTROL,
+            ] and
+            not PP.check_permission_from_serializer(
+                self.context['request'],
+                PP.Permission.CAN_QUALITY_CONTROL,
+            )
+        ):
+            raise serializers.ValidationError('Controlled/Uncontrolled comment are only allowd by QA!!')
+
+        if comment_type == EntryReviewComment.CommentType.VERIFY:
+            if verified_by_qs.exists():
+                raise serializers.ValidationError('Already verified!!')
+            self.pending_commits.append(lambda: self.entry.verified_by.add(current_user))
+        elif comment_type == EntryReviewComment.CommentType.UNVERIFY:
+            if not verified_by_qs.exists():
+                raise serializers.ValidationError('Need to be verified first!!')
+            self.pending_commits.append(lambda: self.entry.verified_by.remove(current_user))
+        elif comment_type == EntryReviewComment.CommentType.CONTROL:
+            if self.entry.controlled:
+                raise serializers.ValidationError('Already controlled!!')
+            self.pending_commits.append(lambda: self.entry.control(current_user))
+        elif comment_type == EntryReviewComment.CommentType.UNCONTROL:
+            if not self.entry.controlled:
+                raise serializers.ValidationError('Need to be controlled first!!')
+            self.pending_commits.append(lambda: self.entry.control(current_user, controlled=False))
+        return comment_type
+
+    def validate_mentioned_users(self, mentioned_users):
+        if mentioned_users:
+            selected_existing_members_count = (
+                ProjectMembership.objects.filter(
+                    project=self.project,
+                    member__in=mentioned_users
+                )
+                .distinct('member').count()
+            )
+            if selected_existing_members_count != len(mentioned_users):
+                raise serializers.ValidationError("Selected mentioned users don't belong to this project")
+        return mentioned_users
+
+    def validate(self, validated_data):
+        text = validated_data['text'] = validated_data.pop('text', '').strip() or (self.instance and self.instance.text)
+        comment_type = (
+            validated_data.get('comment_type') or
+            (self.instance and self.instance.comment_type) or
+            EntryReviewComment.CommentType.COMMENT
+        )
+        # Make sure to check text required
+        if not text and comment_type in [
+            EntryReviewComment.CommentType.COMMENT,
+            EntryReviewComment.CommentType.UNVERIFY,
+            EntryReviewComment.CommentType.UNCONTROL,
+        ]:
+            raise serializers.ValidationError({
+                'text': 'Text is required for comment type',
+            })
+        # Only creator can update
+        if self.instance and self.instance.created_by != self.context['request'].user:
+            raise serializers.ValidationError('Only comment creator can update.')
+        return validated_data
+
+    def comment_save(self, validated_data, instance=None):
+        """
+        Comment Middleware save logic
+        """
+        def _add_comment_text(comment, text):
+            return EntryReviewCommentText.objects.create(
+                comment=comment,
+                text=text,
+            )
+
+        text = validated_data.pop('text')  # Is available from validate()
+        current_text = instance and instance.text
+        text_changed = current_text != text
+        notify_meta = {'text_changed': text_changed}
+
+        if instance is None:  # Create
+            notify_meta['notification_type'] = Notification.ENTRY_REVIEW_COMMENT_ADD
+            notify_meta['text_changed'] = True
+            instance = super().create(validated_data)
+        else:  # Update
+            notify_meta['notification_type'] = Notification.ENTRY_REVIEW_COMMENT_MODIFY
+            current_mentioned_users_pk = list(instance.mentioned_users.values_list('pk', flat=True))
+            notify_meta['new_mentioned_users'] = [
+                user
+                for user in validated_data.get('mentioned_users', [])
+                if user.pk not in current_mentioned_users_pk
+            ]
+            instance = super().update(instance, validated_data)
+            instance.save()
+
+        for pending_commit in self.pending_commits:
+            pending_commit()
+        if text and text_changed:
+            _add_comment_text(instance, text)
+        transaction.on_commit(
+            lambda: send_notifications_for_comment(instance.pk, notify_meta)
+        )
+        return instance
+
+    def create(self, validated_data):
+        validated_data['created_by'] = self.context['request'].user
+        return self.comment_save(validated_data)
+
+    def update(self, instance, validated_data):
+        return self.comment_save(validated_data, instance)

--- a/apps/quality_assurance/tests/test_apis.py
+++ b/apps/quality_assurance/tests/test_apis.py
@@ -4,7 +4,6 @@ from notification.models import Notification
 from project.models import ProjectMembership
 from quality_assurance.models import (
     # EntryReviewComment,
-    CommentType,
     EntryReviewComment,
 )
 
@@ -27,7 +26,7 @@ class QualityAccuranceTests(TestCase):
         self.authenticate(user1)
         data = {
             'text': 'This is a test comment',
-            'comment_type': CommentType.COMMENT,
+            'comment_type': EntryReviewComment.CommentType.COMMENT,
             'mentioned_users': [user1.pk, user2.pk, user3.pk],
         }
         response = self.client.post(f'/api/v1/entries/{entry.pk}/review-comments/', data=data)
@@ -50,7 +49,7 @@ class QualityAccuranceTests(TestCase):
         self.authenticate(user2)
         data = {
             'text': 'This is a test comment',
-            'comment_type': CommentType.COMMENT,
+            'comment_type': EntryReviewComment.CommentType.COMMENT,
             'mentioned_users': [user1.pk, user2.pk, user3.pk],
         }
         response = self.client.post(f'/api/v1/entries/{entry.pk}/review-comments/', data=data)
@@ -64,7 +63,7 @@ class QualityAccuranceTests(TestCase):
         self.authenticate(user4)
         data = {
             'text': 'This is a test comment',
-            'comment_type': CommentType.COMMENT,
+            'comment_type': EntryReviewComment.CommentType.COMMENT,
             'mentioned_users': [user1.pk, user2.pk, user3.pk],
         }
         response = self.client.post(f'/api/v1/entries/{entry.pk}/review-comments/', data=data)
@@ -85,7 +84,7 @@ class QualityAccuranceTests(TestCase):
         self.authenticate(user1)
         data = {
             'text': 'This is a test comment',
-            'comment_type': CommentType.COMMENT,
+            'comment_type': EntryReviewComment.CommentType.COMMENT,
         }
         response = self.client.post(f'/api/v1/entries/{entry.pk}/review-comments/', data=data)
         self.assert_201(response)
@@ -99,7 +98,7 @@ class QualityAccuranceTests(TestCase):
         # Verify
         data = {
             'text': 'This is a test comment for approvable',
-            'comment_type': CommentType.VERIFY,
+            'comment_type': EntryReviewComment.CommentType.VERIFY,
         }
         response = self.client.post(f'/api/v1/entries/{entry.pk}/review-comments/', data=data)
         self.assert_201(response)
@@ -113,7 +112,7 @@ class QualityAccuranceTests(TestCase):
         self.authenticate(user2)
         data = {
             'text': 'This is a test comment',
-            'comment_type': CommentType.VERIFY,
+            'comment_type': EntryReviewComment.CommentType.VERIFY,
         }
         response = self.client.post(f'/api/v1/entries/{entry.pk}/review-comments/', data=data)
         self.assert_201(response)
@@ -122,7 +121,7 @@ class QualityAccuranceTests(TestCase):
         # Unverify
         data = {
             'text': 'This is a test comment for unapprovable',
-            'comment_type': CommentType.UNVERIFY,
+            'comment_type': EntryReviewComment.CommentType.UNVERIFY,
         }
         response = self.client.post(f'/api/v1/entries/{entry.pk}/review-comments/', data=data)
         self.assert_201(response)
@@ -133,7 +132,7 @@ class QualityAccuranceTests(TestCase):
         self.authenticate(user1)
         data = {
             'text': 'This is a test comment',
-            'comment_type': CommentType.VERIFY,
+            'comment_type': EntryReviewComment.CommentType.VERIFY,
         }
         response = self.client.post(f'/api/v1/entries/{entry.pk}/review-comments/', data=data)
         self.assert_400(response)
@@ -144,14 +143,14 @@ class QualityAccuranceTests(TestCase):
         self.authenticate(user2)
         data = {
             'text': 'This is a test comment',
-            'comment_type': CommentType.UNVERIFY,
+            'comment_type': EntryReviewComment.CommentType.UNVERIFY,
         }
         response = self.client.post(f'/api/v1/entries/{entry.pk}/review-comments/', data=data)
         self.assert_400(response)
         self.authenticate(user3)
         data = {
             'text': 'This is a test comment',
-            'comment_type': CommentType.UNVERIFY,
+            'comment_type': EntryReviewComment.CommentType.UNVERIFY,
         }
         response = self.client.post(f'/api/v1/entries/{entry.pk}/review-comments/', data=data)
         self.assert_400(response)
@@ -165,7 +164,7 @@ class QualityAccuranceTests(TestCase):
         user1_membership = project.add_member(user1, role=self.normal_role)
 
         self.authenticate(user1)
-        for comment_type in [CommentType.CONTROL, CommentType.UNCONTROL]:
+        for comment_type in [EntryReviewComment.CommentType.CONTROL, EntryReviewComment.CommentType.UNCONTROL]:
             user1_membership.badges = []
             user1_membership.save()
 
@@ -195,7 +194,7 @@ class QualityAccuranceTests(TestCase):
         self.authenticate(user1)
         data = {
             'text': 'This is a test comment',
-            'comment_type': CommentType.COMMENT,
+            'comment_type': EntryReviewComment.CommentType.COMMENT,
         }
         response = self.client.post(f'/api/v1/entries/{entry.pk}/review-comments/', data=data)
         self.assert_201(response)
@@ -203,7 +202,7 @@ class QualityAccuranceTests(TestCase):
         # Control
         data = {
             'text': 'This is a test comment for control/verify',
-            'comment_type': CommentType.CONTROL,
+            'comment_type': EntryReviewComment.CommentType.CONTROL,
         }
         response = self.client.post(f'/api/v1/entries/{entry.pk}/review-comments/', data=data)
         self.assert_201(response)
@@ -214,7 +213,7 @@ class QualityAccuranceTests(TestCase):
         # Control using same user again
         data = {
             'text': 'This is a test comment to again control already verified',
-            'comment_type': CommentType.CONTROL,
+            'comment_type': EntryReviewComment.CommentType.CONTROL,
         }
         response = self.client.post(f'/api/v1/entries/{entry.pk}/review-comments/', data=data)
         self.assert_400(response)
@@ -226,7 +225,7 @@ class QualityAccuranceTests(TestCase):
         self.authenticate(user2)
         data = {
             'text': 'This is a test comment to again control already verified',
-            'comment_type': CommentType.CONTROL,
+            'comment_type': EntryReviewComment.CommentType.CONTROL,
         }
         response = self.client.post(f'/api/v1/entries/{entry.pk}/review-comments/', data=data)
         self.assert_400(response)
@@ -238,7 +237,7 @@ class QualityAccuranceTests(TestCase):
         self.authenticate(user2)
         data = {
             'text': 'This is a test comment for uncontrol',
-            'comment_type': CommentType.UNCONTROL,
+            'comment_type': EntryReviewComment.CommentType.UNCONTROL,
         }
         response = self.client.post(f'/api/v1/entries/{entry.pk}/review-comments/', data=data)
         self.assert_201(response)
@@ -251,7 +250,7 @@ class QualityAccuranceTests(TestCase):
             # Can't uncontrol already uncontrol
             data = {
                 'text': 'This is a test comment',
-                'comment_type': CommentType.UNVERIFY,
+                'comment_type': EntryReviewComment.CommentType.UNVERIFY,
             }
             response = self.client.post(f'/api/v1/entries/{entry.pk}/review-comments/', data=data)
             self.assert_400(response)
@@ -274,7 +273,7 @@ class QualityAccuranceTests(TestCase):
         self.authenticate(user1)
         data = {
             'text': 'This is a comment',
-            'comment_type': CommentType.COMMENT,
+            'comment_type': EntryReviewComment.CommentType.COMMENT,
         }
         response = self.client.post(f'/api/v1/entries/{entry.pk}/review-comments/', data=data)
         self.assert_201(response)
@@ -283,7 +282,7 @@ class QualityAccuranceTests(TestCase):
             self.authenticate(user)
             data = {
                 'text': 'This is a verify comment',
-                'comment_type': CommentType.VERIFY,
+                'comment_type': EntryReviewComment.CommentType.VERIFY,
             }
             response = self.client.post(f'/api/v1/entries/{entry.pk}/review-comments/', data=data)
             self.assert_201(response)
@@ -291,7 +290,7 @@ class QualityAccuranceTests(TestCase):
         self.authenticate(user4)
         data = {
             'text': 'This is a control comment',
-            'comment_type': CommentType.CONTROL,
+            'comment_type': EntryReviewComment.CommentType.CONTROL,
         }
         response = self.client.post(f'/api/v1/entries/{entry.pk}/review-comments/', data=data)
         self.assert_201(response)
@@ -312,7 +311,7 @@ class QualityAccuranceTests(TestCase):
             self.authenticate(user)
             data = {
                 'text': 'This is a verify comment',
-                'comment_type': CommentType.VERIFY,
+                'comment_type': EntryReviewComment.CommentType.VERIFY,
             }
             response = self.client.post(f'/api/v1/entries/{entry.pk}/review-comments/', data=data)
             self.assert_201(response)
@@ -325,7 +324,7 @@ class QualityAccuranceTests(TestCase):
         self.authenticate(user)
         data = {
             'text': 'This is a control comment',
-            'comment_type': CommentType.CONTROL,
+            'comment_type': EntryReviewComment.CommentType.CONTROL,
         }
         response = self.client.post(f'/api/v1/entries/{entry.pk}/review-comments/', data=data)
         self.assert_201(response)
@@ -343,11 +342,11 @@ class QualityAccuranceTests(TestCase):
 
         for comment_type, text_required in [
                 (None, True),  # Default is CommentType.COMMENT
-                (CommentType.COMMENT, True),
-                (CommentType.VERIFY, False),
-                (CommentType.UNVERIFY, True),
-                (CommentType.CONTROL, False),
-                (CommentType.UNCONTROL, True),
+                (EntryReviewComment.CommentType.COMMENT, True),
+                (EntryReviewComment.CommentType.VERIFY, False),
+                (EntryReviewComment.CommentType.UNVERIFY, True),
+                (EntryReviewComment.CommentType.CONTROL, False),
+                (EntryReviewComment.CommentType.UNCONTROL, True),
         ]:
             self.authenticate(user1)
             data = {}
@@ -399,7 +398,7 @@ class QualityAccuranceTests(TestCase):
         _clear_notifications()
         data = {
             'text': 'This is a comment',
-            'comment_type': CommentType.COMMENT,
+            'comment_type': EntryReviewComment.CommentType.COMMENT,
             'mentioned_users': [user2.pk],
         }
         # Need self.captureOnCommitCallbacks as this API uses transation.on_commit
@@ -415,7 +414,7 @@ class QualityAccuranceTests(TestCase):
         _clear_notifications()
         data = {
             'text': 'This is a comment',
-            'comment_type': CommentType.COMMENT,
+            'comment_type': EntryReviewComment.CommentType.COMMENT,
             'mentioned_users': [user2.pk, user3.pk, user1.pk],
         }
         # Need self.captureOnCommitCallbacks as this API uses transation.on_commit
@@ -429,8 +428,8 @@ class QualityAccuranceTests(TestCase):
 
         # Create a commit different comment_type
         for comment_type in [
-            CommentType.VERIFY, CommentType.UNVERIFY,
-            CommentType.CONTROL, CommentType.UNCONTROL,
+            EntryReviewComment.CommentType.VERIFY, EntryReviewComment.CommentType.UNVERIFY,
+            EntryReviewComment.CommentType.CONTROL, EntryReviewComment.CommentType.UNCONTROL,
         ]:
             _clean_comments(project)
             _clear_notifications()

--- a/apps/quality_assurance/tests/test_mutations.py
+++ b/apps/quality_assurance/tests/test_mutations.py
@@ -1,0 +1,538 @@
+from utils.graphene.tests import GraphQLTestCase
+
+from quality_assurance.models import EntryReviewComment
+from project.models import ProjectMembership
+from notification.models import Notification
+from entry.models import Entry
+
+from user.factories import UserFactory
+from analysis_framework.factories import AnalysisFrameworkFactory
+from project.factories import ProjectFactory
+from lead.factories import LeadFactory
+from entry.factories import EntryFactory
+
+
+VerifiedByQs = Entry.verified_by.through.objects
+
+
+class TestQualityAssuranceMutation(GraphQLTestCase):
+
+    CREATE_ENTRY_REVIEW_COMMENT_QUERY = '''
+        mutation MyMutation ($projectId: ID!, $input: EntryReviewCommentInputType!) {
+          project(id: $projectId) {
+            entryReviewCommentCreate(data: $input) {
+              ok
+              errors
+              result {
+                id
+                commentType
+                createdAt
+                text
+                createdBy {
+                  id
+                  displayName
+                }
+                mentionedUsers {
+                  id
+                  displayName
+                }
+                textHistory {
+                  id
+                  createdAt
+                  text
+                }
+              }
+            }
+          }
+        }
+    '''
+
+    UPDATE_ENTRY_REVIEW_COMMENT_QUERY = '''
+        mutation MyMutation ($projectId: ID!, $reviewCommentId: ID!, $input: EntryReviewCommentInputType!) {
+          project(id: $projectId) {
+            entryReviewCommentUpdate(id: $reviewCommentId data: $input) {
+              ok
+              errors
+              result {
+                id
+                commentType
+                createdAt
+                text
+                createdBy {
+                  id
+                  displayName
+                }
+                mentionedUsers {
+                  id
+                  displayName
+                }
+                textHistory {
+                  id
+                  createdAt
+                  text
+                }
+              }
+            }
+          }
+        }
+
+    '''
+
+    def setUp(self):
+        super().setUp()
+        self.qa_member_user = UserFactory.create()
+        self.member_user = UserFactory.create()
+        self.readonly_member_user = UserFactory.create()
+        self.non_member_user = UserFactory.create()
+        self.af = AnalysisFrameworkFactory.create()
+        self.project = ProjectFactory.create(analysis_framework=self.af)
+        self.lead = LeadFactory.create(project=self.project)
+        self.entry = EntryFactory.create(lead=self.lead)
+        # Add member to project
+        self.project.add_member(self.readonly_member_user, role=self.project_role_viewer_non_confidential)
+        self.project.add_member(self.member_user, role=self.project_role_analyst)
+        self.project.add_member(self.qa_member_user, role=self.project_role_analyst, badges=[ProjectMembership.BadgeType.QA])
+
+    def _query_check(self, mutation_input, review_comment_id=None, **kwargs):
+        variables = {'projectId': self.project.id}
+        query = self.CREATE_ENTRY_REVIEW_COMMENT_QUERY
+        if review_comment_id:
+            query = self.UPDATE_ENTRY_REVIEW_COMMENT_QUERY
+            variables['reviewCommentId'] = review_comment_id
+        return self.query_check(
+            query,
+            minput=mutation_input,
+            mnested=['project'],
+            variables=variables,
+            **kwargs
+        )
+
+    def test_entry_review_comment_create(self):
+        minput = {
+            'entry': self.entry.id,
+            'commentType': self.genum(EntryReviewComment.CommentType.COMMENT),
+            # 'mentionedUsers': [self.readonly_member_user.pk, self.qa_member_user.pk],
+        }
+
+        def _get_notifications_receivers():
+            return set(
+                Notification.objects.values_list('receiver', flat=True)
+            ), set(
+                Notification.objects.values_list('notification_type', flat=True).distinct()
+            )
+
+        # -- Without login
+        self._query_check(minput, assert_for_error=True)
+
+        # -- With login (non-member)
+        self.force_login(self.non_member_user)
+        self._query_check(minput, assert_for_error=True)
+
+        # --- member user (read-only)
+        self.force_login(self.readonly_member_user)
+        self._query_check(minput, assert_for_error=True)
+
+        # --- member user
+        self.force_login(self.member_user)
+
+        # Invalid input (Comment without text)
+        self.entry.controlled = True
+        self.entry.save(update_fields=('controlled',))
+        minput = {
+            'entry': self.entry.id,
+            'commentType': self.genum(EntryReviewComment.CommentType.CONTROL),
+        }
+
+        self._query_check(minput, okay=False)
+
+        # Control
+        self.entry.controlled = False
+        self.entry.save(update_fields=('controlled',))
+        self._query_check(minput, okay=False)
+        self.force_login(self.qa_member_user)
+        minput['commentType'] = self.genum(EntryReviewComment.CommentType.UNCONTROL)
+        self._query_check(minput, okay=False)
+        minput['commentType'] = self.genum(EntryReviewComment.CommentType.CONTROL)
+        self._query_check(minput, okay=True)  # If request by a QA User
+
+        minput['commentType'] = self.genum(EntryReviewComment.CommentType.UNCONTROL)
+        self.force_login(self.member_user)
+        self._query_check(minput, okay=False)
+        self.force_login(self.qa_member_user)
+        self._query_check(minput, okay=False)  # Text is required
+        minput['text'] = 'sample text'
+        self._query_check(minput, okay=True)  # If request by a QA User
+
+        # Verify
+        self.force_login(self.member_user)
+        minput.pop('text')
+        minput['commentType'] = self.genum(EntryReviewComment.CommentType.VERIFY)
+        self._query_check(minput, okay=True)
+        minput['commentType'] = self.genum(EntryReviewComment.CommentType.VERIFY)
+        self._query_check(minput, okay=False)
+        minput['commentType'] = self.genum(EntryReviewComment.CommentType.UNVERIFY)
+        self._query_check(minput, okay=False)
+        minput['text'] = 'sample text'
+        self._query_check(minput, okay=True)
+        minput['commentType'] = self.genum(EntryReviewComment.CommentType.UNVERIFY)
+        self._query_check(minput, okay=False)
+
+    def test_entry_review_comment_basic_api(self):
+        user1 = UserFactory.create()
+        user2 = UserFactory.create()
+        user3 = UserFactory.create()
+        user4 = UserFactory.create()
+        self.project.add_member(user1, role=self.project_role_analyst, badges=[ProjectMembership.BadgeType.QA])
+        self.project.add_member(user2, role=self.project_role_analyst, badges=[ProjectMembership.BadgeType.QA])
+        self.project.add_member(user3, role=self.project_role_analyst, badges=[ProjectMembership.BadgeType.QA])
+
+        self.force_login(user1)
+        data = {
+            'entry': self.entry.pk,
+            'text': 'This is a test comment',
+            'commentType': self.genum(EntryReviewComment.CommentType.COMMENT),
+            'mentionedUsers': [user1.pk, user2.pk, user3.pk],
+        }
+        comment_pk = self._query_check(data, okay=True)['data']['project']['entryReviewCommentCreate']['result']['id']
+
+        assert self.entry.entryreviewcomment_set.count() == 1
+
+        # Update only allowd by comment creater
+        data['text'] = 'This is updated text comment'
+        content = self._query_check(
+            data, review_comment_id=comment_pk, okay=True)['data']['project']['entryReviewCommentUpdate']
+        self.assertEqual(content['result']['textHistory'][0]['text'], data['text'])
+        self.force_login(user2)
+        self._query_check(data, review_comment_id=comment_pk, assert_for_error=True)
+
+        self.force_login(user2)
+        data = {
+            'entry': self.entry.pk,
+            'text': 'This is a test comment',
+            'commentType': self.genum(EntryReviewComment.CommentType.COMMENT),
+            'mentionedUsers': [user1.pk, user2.pk, user3.pk],
+        }
+        self._query_check(data, okay=True)
+
+        assert self.entry.entryreviewcomment_set.count() == 2
+
+        self.force_login(user4)
+        data = {
+            'entry': self.entry.pk,
+            'text': 'This is a test comment',
+            'commentType': self.genum(EntryReviewComment.CommentType.COMMENT),
+            'mentionedUsers': [user1.pk, user2.pk, user3.pk],
+        }
+        self._query_check(data, assert_for_error=True)
+
+    def test_entry_review_comment_verify_api(self):
+        user1 = UserFactory.create()
+        user2 = UserFactory.create()
+        user3 = UserFactory.create()
+        self.project.add_member(user1, role=self.project_role_analyst, badges=[ProjectMembership.BadgeType.QA])
+        self.project.add_member(user2, role=self.project_role_analyst, badges=[ProjectMembership.BadgeType.QA])
+        self.project.add_member(user3, role=self.project_role_analyst, badges=[ProjectMembership.BadgeType.QA])
+
+        self.force_login(user1)
+        data = {
+            'entry': self.entry.pk,
+            'text': 'This is a test comment',
+            'commentType': self.genum(EntryReviewComment.CommentType.COMMENT),
+        }
+        self._query_check(data, okay=True)
+        assert VerifiedByQs.filter(entry=self.entry).count() == 0
+
+        # Verify
+        data = {
+            'entry': self.entry.pk,
+            'text': 'This is a test comment for approvable',
+            'commentType': self.genum(EntryReviewComment.CommentType.VERIFY),
+        }
+        self._query_check(data, okay=True)
+        assert VerifiedByQs.filter(entry=self.entry).count() == 1
+
+        self.force_login(user2)
+        data = {
+            'entry': self.entry.pk,
+            'text': 'This is a test comment',
+            'commentType': self.genum(EntryReviewComment.CommentType.VERIFY),
+        }
+        self._query_check(data, okay=True)
+        assert VerifiedByQs.filter(entry=self.entry).count() == 2
+
+        # Unverify
+        data = {
+            'entry': self.entry.pk,
+            'text': 'This is a test comment for unapprovable',
+            'commentType': self.genum(EntryReviewComment.CommentType.UNVERIFY),
+        }
+        self._query_check(data, okay=True)
+
+        assert VerifiedByQs.filter(entry=self.entry).count() == 1
+
+        # Can't verify already verify
+        self.force_login(user1)
+        data = {
+            'entry': self.entry.pk,
+            'text': 'This is a test comment',
+            'commentType': self.genum(EntryReviewComment.CommentType.VERIFY),
+        }
+        self._query_check(data, okay=False)
+
+        assert VerifiedByQs.filter(entry=self.entry).count() == 1
+
+        # Can't unverify not verify
+        self.force_login(user2)
+        data = {
+            'entry': self.entry.pk,
+            'text': 'This is a test comment',
+            'commentType': self.genum(EntryReviewComment.CommentType.UNVERIFY),
+        }
+        self._query_check(data, okay=False)
+
+        self.force_login(user3)
+        data = {
+            'entry': self.entry.pk,
+            'text': 'This is a test comment',
+            'commentType': self.genum(EntryReviewComment.CommentType.UNVERIFY),
+        }
+        self._query_check(data, okay=False)
+
+        assert VerifiedByQs.filter(entry=self.entry).count() == 1
+
+    def test_entry_review_comment_project_qa_badge_api(self):
+        user1 = UserFactory.create()
+        user1_membership = self.project.add_member(user1, role=self.project_role_analyst)
+
+        self.force_login(user1)
+        for comment_type in [
+            EntryReviewComment.CommentType.CONTROL,
+            EntryReviewComment.CommentType.UNCONTROL,
+        ]:
+            user1_membership.badges = []
+            user1_membership.save()
+
+            data = {
+                'entry': self.entry.pk,
+                'text': 'This is a test comment',
+                'commentType': self.genum(comment_type),
+            }
+            self._query_check(data, okay=False)
+
+            user1_membership.badges = [ProjectMembership.BadgeType.QA]
+            user1_membership.save()
+
+            self._query_check(data, okay=True)
+
+    def test_entry_review_comment_control_api(self):
+        user1 = UserFactory.create()
+        user2 = UserFactory.create()
+        user3 = UserFactory.create()
+        self.project.add_member(user1, role=self.project_role_analyst, badges=[ProjectMembership.BadgeType.QA])
+        self.project.add_member(user2, role=self.project_role_analyst, badges=[ProjectMembership.BadgeType.QA])
+        self.project.add_member(user3, role=self.project_role_analyst)
+
+        self.force_login(user1)
+        data = {
+            'entry': self.entry.pk,
+            'text': 'This is a test comment',
+            'commentType': self.genum(EntryReviewComment.CommentType.COMMENT),
+        }
+        self._query_check(data, okay=True)
+
+        # Control
+        data = {
+            'entry': self.entry.pk,
+            'text': 'This is a test comment for control/verify',
+            'commentType': self.genum(EntryReviewComment.CommentType.CONTROL),
+        }
+        self._query_check(data, okay=True)
+        self.entry.refresh_from_db()
+        assert self.entry.controlled
+        assert self.entry.controlled_changed_by == user1
+
+        # Control using same user again
+        data = {
+            'entry': self.entry.pk,
+            'text': 'This is a test comment to again control already verified',
+            'commentType': self.genum(EntryReviewComment.CommentType.CONTROL),
+        }
+        self._query_check(data, okay=False)
+        self.entry.refresh_from_db()
+        assert self.entry.controlled
+        assert self.entry.controlled_changed_by == user1
+
+        # Control using another user again
+        self.force_login(user2)
+        data = {
+            'entry': self.entry.pk,
+            'text': 'This is a test comment to again control already verified',
+            'commentType': self.genum(EntryReviewComment.CommentType.CONTROL),
+        }
+        self._query_check(data, okay=False)
+        self.entry.refresh_from_db()
+        assert self.entry.controlled
+        assert self.entry.controlled_changed_by == user1
+
+        # Uncontrol (any users can also uncontrol)
+        self.force_login(user2)
+        data = {
+            'entry': self.entry.pk,
+            'text': 'This is a test comment for uncontrol',
+            'commentType': self.genum(EntryReviewComment.CommentType.UNCONTROL),
+        }
+        self._query_check(data, okay=True)
+        self.entry.refresh_from_db()
+        assert not self.entry.controlled
+        assert self.entry.controlled_changed_by == user2
+
+        for user in [user1, user2]:
+            self.force_login(user)
+            # Can't uncontrol already uncontrol
+            data = {
+                'entry': self.entry.pk,
+                'text': 'This is a test comment',
+                'commentType': self.genum(EntryReviewComment.CommentType.UNVERIFY),
+            }
+            self._query_check(data, okay=False)
+            self.entry.refresh_from_db()
+            assert not self.entry.controlled
+            assert self.entry.controlled_changed_by == user2
+
+    def test_entry_review_comment_create_text_required(self):
+        self.force_login(self.qa_member_user)
+
+        # Text required
+        for comment_type, text_required in [
+                (None, True),  # Default is CommentType.COMMENT
+                (EntryReviewComment.CommentType.COMMENT, True),
+                (EntryReviewComment.CommentType.VERIFY, False),
+                (EntryReviewComment.CommentType.UNVERIFY, True),
+                (EntryReviewComment.CommentType.CONTROL, False),
+                (EntryReviewComment.CommentType.UNCONTROL, True),
+        ]:
+            _minput = {'entry': self.entry.pk}
+            if comment_type:
+                _minput['commentType'] = self.genum(comment_type)
+            if text_required:
+                self._query_check(_minput, okay=False)
+                _minput['text'] = 'This is a comment'
+                self._query_check(_minput, okay=True)
+            else:
+                self._query_check(_minput, okay=True)
+
+    def test_entry_review_comment_notification(self):
+        def _get_comment_users_pk(pk):
+            return set(
+                EntryReviewComment.objects.get(pk=pk).get_related_users().values_list('pk', flat=True)
+            )
+
+        def _clean_comments(project):
+            return EntryReviewComment.objects.filter(entry__project=project).delete()
+
+        def _clear_notifications():
+            return Notification.objects.all().delete()
+
+        def _get_notifications_receivers():
+            return set(
+                Notification.objects.values_list('receiver', flat=True)
+            ), set(
+                Notification.objects.values_list('notification_type', flat=True).distinct()
+            )
+
+        user1 = UserFactory.create()
+        user2 = UserFactory.create()
+        user3 = UserFactory.create()
+        user4 = UserFactory.create()
+        self.project.add_member(user1, role=self.project_role_analyst, badges=[ProjectMembership.BadgeType.QA])
+        self.project.add_member(user2, role=self.project_role_analyst, badges=[ProjectMembership.BadgeType.QA])
+        self.project.add_member(user3, role=self.project_role_analyst, badges=[ProjectMembership.BadgeType.QA])
+        self.project.add_member(user4, role=self.project_role_analyst, badges=[ProjectMembership.BadgeType.QA])
+
+        self.force_login(self.qa_member_user)
+
+        # Create a commit
+        _clear_notifications()
+        minput = {
+            'entry': self.entry.id,
+            'text': 'This is a comment',
+            'commentType': self.genum(EntryReviewComment.CommentType.COMMENT),
+            'mentionedUsers': [user2.pk],
+        }
+        # Need self.captureOnCommitCallbacks as this API uses transation.on_commit
+        with self.captureOnCommitCallbacks(execute=True):
+            comment_id = self._query_check(minput, okay=True)['data']['project']['entryReviewCommentCreate']['result']['id']
+        assert _get_comment_users_pk(comment_id) == set([user2.pk])
+        assert _get_notifications_receivers() == (
+            set([user2.pk]),
+            set([Notification.ENTRY_REVIEW_COMMENT_ADD]),
+        )
+
+        # Create a commit (multiple mentionedUsers)
+        _clear_notifications()
+        minput = {
+            'entry': self.entry.id,
+            'text': 'This is a comment',
+            'commentType': self.genum(EntryReviewComment.CommentType.COMMENT),
+            'mentionedUsers': [user2.pk, user3.pk, self.qa_member_user.pk],
+        }
+        # Need self.captureOnCommitCallbacks as this API uses transation.on_commit
+        with self.captureOnCommitCallbacks(execute=True):
+            comment_id = self._query_check(minput, okay=True)['data']['project']['entryReviewCommentCreate']['result']['id']
+        assert _get_comment_users_pk(comment_id) == set([user2.pk, user3.pk])
+        assert _get_notifications_receivers() == (
+            set([user2.pk, user3.pk]),
+            set([Notification.ENTRY_REVIEW_COMMENT_ADD]),
+        )
+
+        # Create a commit different comment_type
+        for comment_type in [
+            EntryReviewComment.CommentType.VERIFY, EntryReviewComment.CommentType.UNVERIFY,
+            EntryReviewComment.CommentType.CONTROL, EntryReviewComment.CommentType.UNCONTROL,
+        ]:
+            _clean_comments(self.project)
+            _clear_notifications()
+            minput = {
+                'entry': self.entry.id,
+                'text': 'This is a comment',
+                'commentType': self.genum(comment_type),
+                'mentionedUsers': [self.qa_member_user.pk, user2.pk, user3.pk],
+            }
+            # Need self.captureOnCommitCallbacks as this API uses transation.on_commit
+            with self.captureOnCommitCallbacks(execute=True):
+                comment_id = self._query_check(
+                    minput, okay=True)['data']['project']['entryReviewCommentCreate']['result']['id']
+            assert _get_comment_users_pk(comment_id) == set([user2.pk, user3.pk])
+            assert _get_notifications_receivers() == (
+                set([user2.pk, user3.pk]),
+                set([Notification.ENTRY_REVIEW_COMMENT_ADD]),
+            )
+
+            _clear_notifications()
+            # Need self.captureOnCommitCallbacks as this API uses transation.on_commit
+            with self.captureOnCommitCallbacks(execute=True):
+                self._query_check(minput, review_comment_id=comment_id, okay=True)
+            assert _get_comment_users_pk(comment_id) == set([user2.pk, user3.pk])
+            assert _get_notifications_receivers() == (set(), set())  # No new notifications are created
+
+            _clear_notifications()
+            minput['text'] = 'this is a new comment text'
+            # Need self.captureOnCommitCallbacks as this API uses transation.on_commit
+            with self.captureOnCommitCallbacks(execute=True):
+                self._query_check(minput, review_comment_id=comment_id, okay=True)
+            assert _get_comment_users_pk(comment_id) == set([user2.pk, user3.pk])
+            assert _get_notifications_receivers() == (
+                set([user2.pk, user3.pk]),
+                set([Notification.ENTRY_REVIEW_COMMENT_MODIFY]),
+            )  # New notifications are created
+
+            _clear_notifications()
+            minput['mentionedUsers'].append(user4.pk)
+            # Need self.captureOnCommitCallbacks as this API uses transation.on_commit
+            with self.captureOnCommitCallbacks(execute=True):
+                self._query_check(minput, review_comment_id=comment_id, okay=True)
+            assert _get_comment_users_pk(comment_id) == set([user4.pk, user2.pk, user3.pk])
+            assert _get_notifications_receivers() == (
+                set([user4.pk]),
+                set([Notification.ENTRY_REVIEW_COMMENT_MODIFY]),
+            )  # New notifications are created only for user2

--- a/apps/quality_assurance/tests/test_schemas.py
+++ b/apps/quality_assurance/tests/test_schemas.py
@@ -39,6 +39,7 @@ class TestReviewCommentQuery(GraphQLTestCase):
                             }
                             text
                         }
+                        reviewCommentsCount
                     }
                 }
             }
@@ -77,6 +78,7 @@ class TestReviewCommentQuery(GraphQLTestCase):
         # --- add-member in project
         project.add_member(user)
         content = self.query_check(query, variables={'projectId': project.id, 'entryId': entry.id})
+        self.assertEqual(content['data']['project']['entry']['reviewCommentsCount'], 2, content)
         self.assertEqual(len(content['data']['project']['entry']['reviewComments']), 2, content)
         self.assertListIds(
             content['data']['project']['entry']['reviewComments'],
@@ -92,6 +94,7 @@ class TestReviewCommentQuery(GraphQLTestCase):
         # add another review_text for same review_comment
         review_text2 = EntryReviewCommentTextFactory.create(comment=review_comment1)
         content = self.query_check(query, variables={'projectId': project.id, 'entryId': entry.id})
+        self.assertEqual(content['data']['project']['entry']['reviewCommentsCount'], 2, content)
         self.assertEqual(
             content['data']['project']['entry']['reviewComments'][1]['text'],
             review_text2.text,  # here latest text should be present
@@ -105,6 +108,7 @@ class TestReviewCommentQuery(GraphQLTestCase):
 
         # lets query for another entry
         content = self.query_check(query, variables={'projectId': project.id, 'entryId': entry1.id})
+        self.assertEqual(content['data']['project']['entry']['reviewCommentsCount'], 1, content)
         self.assertEqual(len(content['data']['project']['entry']['reviewComments']), 1, content)
 
     def test_review_comments_project_scope_query(self):

--- a/deep/graphene_context.py
+++ b/deep/graphene_context.py
@@ -10,7 +10,6 @@ from deep.dataloaders import GlobalDataLoaders
 class GQLContext:
     def __init__(self, request):
         self.request = request
-        self.request.gql_context = self  # To be used from serializers
         # Project
         self.active_project = self.request.active_project = None
         self.project_permissions = []

--- a/deep/graphene_context.py
+++ b/deep/graphene_context.py
@@ -10,6 +10,7 @@ from deep.dataloaders import GlobalDataLoaders
 class GQLContext:
     def __init__(self, request):
         self.request = request
+        self.request.gql_context = self  # To be used from serializers
         # Project
         self.active_project = self.request.active_project = None
         self.project_permissions = []

--- a/deep/permissions.py
+++ b/deep/permissions.py
@@ -226,6 +226,12 @@ class BasePermissions():
         if permissions:
             return all([perm in permissions for perm in perms])
 
+    @classmethod
+    def check_permission_from_serializer(cls, context, *perms):
+        permissions = getattr(context, cls.CONTEXT_PERMISSION_ATTR)
+        if permissions:
+            return all([perm in permissions for perm in perms])
+
 
 class ProjectPermissions(BasePermissions):
 

--- a/deep/views.py
+++ b/deep/views.py
@@ -20,7 +20,7 @@ from deep.exceptions import PermissionDeniedException
 from user.models import User, Profile
 from project.models import Project
 from entry.models import EntryComment
-from quality_assurance.models import EntryReviewComment, CommentType
+from quality_assurance.models import EntryReviewComment
 from notification.models import Notification
 
 
@@ -193,7 +193,7 @@ class EntryReviewCommentEmail(View):
         context.update({
             'email_type': Profile.E_EMAIL_COMMENT,
             'notification_type': notification_type,
-            'CommentType': CommentType,
+            'CommentType': EntryReviewComment.CommentType,
             'Notification': Notification,
             'comment': comment,
         })

--- a/schema.graphql
+++ b/schema.graphql
@@ -227,6 +227,12 @@ type CreateEntry {
   result: EntryType
 }
 
+type CreateEntryReviewComment {
+  errors: [GenericScalar!]
+  ok: Boolean
+  result: EntryReviewCommentDetailType
+}
+
 type CreateLead {
   errors: [GenericScalar!]
   ok: Boolean
@@ -375,18 +381,24 @@ type EntryReviewCommentDetailType {
   createdBy: UserType!
   createdAt: DateTime!
   mentionedUsers: [UserType!]!
-  entry: EntryType!
-  commentType: ReviewCommentTypeEnum!
+  entry: ID!
+  commentType: EntryReviewCommentTypeEnum!
   commentTypeDisplay: EnumDescription!
   text: String
   textHistory: [EntryReviewCommentTextType!]
+}
+
+input EntryReviewCommentInputType {
+  entry: ID!
+  commentType: EntryReviewCommentTypeEnum
+  text: String
+  mentionedUsers: [ID!]
 }
 
 type EntryReviewCommentTextType {
   id: ID!
   createdAt: DateTime!
   text: String!
-  comment: EntryReviewCommentDetailType!
 }
 
 type EntryReviewCommentType {
@@ -394,10 +406,18 @@ type EntryReviewCommentType {
   createdBy: UserType!
   createdAt: DateTime!
   mentionedUsers: [UserType!]!
-  entry: EntryType!
-  commentType: ReviewCommentTypeEnum!
+  commentType: EntryReviewCommentTypeEnum!
   commentTypeDisplay: EnumDescription!
   text: String
+  entry: ID!
+}
+
+enum EntryReviewCommentTypeEnum {
+  COMMENT
+  VERIFY
+  UNVERIFY
+  CONTROL
+  UNCONTROL
 }
 
 enum EntryTagTypeEnum {
@@ -426,6 +446,7 @@ type EntryType {
   projectLabels: [EntryGroupLabelType!]
   verifiedBy: [UserType!]
   reviewComments: [EntryReviewCommentType!]
+  reviewCommentsCount: Int!
 }
 
 scalar EnumDescription
@@ -951,6 +972,8 @@ type ProjectMembershipType {
 type ProjectMutationType {
   id: ID!
   title: String!
+  entryReviewCommentCreate(data: EntryReviewCommentInputType!): CreateEntryReviewComment
+  entryReviewCommentUpdate(data: EntryReviewCommentInputType!, id: ID!): UpdateEntryReviewComment
   entryCreate(data: EntryInputType!): CreateEntry
   entryUpdate(data: EntryInputType!, id: ID!): UpdateEntry
   entryDelete(id: ID!): DeleteEntry
@@ -1113,14 +1136,6 @@ input ResetPasswordInputType {
   captcha: String!
 }
 
-enum ReviewCommentTypeEnum {
-  COMMENT
-  VERIFY
-  UNVERIFY
-  CONTROL
-  UNCONTROL
-}
-
 input SectionGqlInputType {
   id: ID
   title: String!
@@ -1149,6 +1164,12 @@ type UpdateEntry {
   errors: [GenericScalar!]
   ok: Boolean
   result: EntryType
+}
+
+type UpdateEntryReviewComment {
+  errors: [GenericScalar!]
+  ok: Boolean
+  result: EntryReviewCommentDetailType
 }
 
 type UpdateLead {


### PR DESCRIPTION
Addresses
- #976
- #975
- #927

## Changes

- Add mutation for Quality Assurance.
    - Add tests.
    - Migrate CommentType -> EntryReviewComment.CommentType.
    - Convert CommentType from django_enum to django textchoices enum.
- Add validation for makemigrations
![2021-10-04-130234](https://user-images.githubusercontent.com/7059255/135809808-e49ab37a-69a4-43fd-9a02-c224060066b6.png)


Mention related users here if any.
@tnagorra @samshara @AdityaKhatri, New schema have some breaking changes.

## This PR doesn't introduce any:

- [x] temporary files, auto-generated files or secret keys
- [x] n+1 queries
- [x] flake8 issues
- [x] `print`
- [x] typos
- [x] unwanted comments

## This PR contains valid:

- [x] tests
- [x] permission checks (tests here too)
- [ ] translations
