### PR TITLE
Filter entries from lead query for different AF.

### DIFF
--- a/apps/lead/dataloaders.py
+++ b/apps/lead/dataloaders.py
@@ -20,16 +20,23 @@ class LeadPreviewLoader(DataLoaderWithContext):
 
 class EntriesCountLoader(DataLoaderWithContext):
     def batch_load_fn(self, keys):
+        active_af = self.context.active_project.analysis_framework
         stat_qs = Entry.objects\
             .filter(lead__in=keys)\
             .order_by('lead').values('lead')\
             .annotate(
                 total=models.functions.Coalesce(
-                    models.Count('id'),
+                    models.Count(
+                        'id',
+                        filter=models.Q(analysis_framework=active_af)
+                    ),
                     0,
                 ),
                 controlled=models.functions.Coalesce(
-                    models.Count('id', filter=models.Q(controlled=True)),
+                    models.Count(
+                        'id',
+                        filter=models.Q(controlled=True, analysis_framework=active_af)
+                    ),
                     0,
                 ),
             ).values('lead_id', 'total', 'controlled')

--- a/apps/lead/schema.py
+++ b/apps/lead/schema.py
@@ -202,7 +202,9 @@ class LeadDetailType(LeadType):
 
     @staticmethod
     def resolve_entries(root, info, **kwargs):
-        return root.entry_set.all()
+        return root.entry_set.filter(
+            analysis_framework=info.context.active_project.analysis_framework,
+        ).all()
 
 
 class LeadListType(CustomDjangoListObjectType):

--- a/deep/serializers.py
+++ b/deep/serializers.py
@@ -140,8 +140,8 @@ class TempClientIdMixin(serializers.ModelSerializer):
     client_id = serializers.CharField(required=False)
 
     @staticmethod
-    def get_cache_key(instance):
-        return f'{type(instance).__name__}-{instance.id}'
+    def get_cache_key(instance, request):
+        return f'{hash(request)}-{type(instance).__name__}-{instance.id}'
 
     def _get_temp_client_id(self, validated_data):
         try:
@@ -158,7 +158,7 @@ class TempClientIdMixin(serializers.ModelSerializer):
         instance = super().create(validated_data)
         if temp_client_id:
             instance.client_id = temp_client_id
-            local_cache.set(self.get_cache_key(instance), temp_client_id, 60)
+            local_cache.set(self.get_cache_key(instance, self.context['request']), temp_client_id, 60)
         return instance
 
     def update(self, instance, validated_data):
@@ -166,7 +166,7 @@ class TempClientIdMixin(serializers.ModelSerializer):
         instance = super().update(instance, validated_data)
         if temp_client_id:
             instance.client_id = temp_client_id
-            local_cache.set(self.get_cache_key(instance), temp_client_id, 60)
+            local_cache.set(self.get_cache_key(instance, self.context['request']), temp_client_id, 60)
         return instance
 
 

--- a/utils/graphene/tests.py
+++ b/utils/graphene/tests.py
@@ -181,7 +181,7 @@ class GraphQLTestCase(CommonSetupClassMixin, BaseGraphQLTestCase):
 
     def assertListIds(
         self,
-        current_list, excepted_list, message,
+        current_list, excepted_list, message=None,
         get_current_list_id=lambda x: str(x['id']),
         get_excepted_list_id=lambda x: str(x.id),
     ):

--- a/utils/graphene/types.py
+++ b/utils/graphene/types.py
@@ -22,11 +22,11 @@ class ClientIdMixin(graphene.ObjectType):
     client_id = graphene.String(required=True)
 
     @staticmethod
-    def resolve_client_id(root, _):
+    def resolve_client_id(root, info):
         # NOTE: We should always provide non-null client_id
         client_id = (
             getattr(root, 'client_id', None) or
-            local_cache.get(TempClientIdMixin.get_cache_key(root)) or
+            local_cache.get(TempClientIdMixin.get_cache_key(root, info.context)) or
             root.id
         )
         if client_id is not None:


### PR DESCRIPTION
Addresses https://zube.io/deep/deep/c/4178

## Changes

* Entries count issue in Graphql
* Fix orphan clientId value appearing in widget objects.

Mention related users here if any.

## This PR doesn't introduce any:

- [x] temporary files, auto-generated files or secret keys
- [x] n+1 queries
- [x] flake8 issues
- [x] `print`
- [x] typos
- [x] unwanted comments

## This PR contains valid:

- [x] tests
- [ ] permission checks (tests here too)
- [ ] translations