### PR TITLE
Fix notification trigerred twice on project_accept

### DIFF
--- a/apps/notification/receivers/project_membership.py
+++ b/apps/notification/receivers/project_membership.py
@@ -24,7 +24,7 @@ def create_notification(sender, instance, created, **kwargs):
             )
         return
 
-    # notifiy the requester as well
+    # notify the requester as well
     if instance.status in ['accepted', 'rejected']:
         Notification.objects.create(
             receiver=instance.requested_by,

--- a/apps/project/tests/test_mutations.py
+++ b/apps/project/tests/test_mutations.py
@@ -360,6 +360,11 @@ class TestProjectJoinAcceptRejectMutation(GraphQLTestCase):
             variables={'projectId': project.id, 'joinRequestId': join_request.id},
             assert_for_error=True
         )
+        notification_qs = Notification.objects.filter(
+            receiver=user,
+            notification_type=Notification.Type.PROJECT_JOIN_RESPONSE
+        )
+        old_count = notification_qs.count()
 
         # with login
         self.force_login(user)
@@ -380,12 +385,7 @@ class TestProjectJoinAcceptRejectMutation(GraphQLTestCase):
         )
         # make sure memberships is created
         self.assertIn(user2.id, ProjectMembership.objects.filter(project=project).values_list('member', flat=True))
-
-        # Make sure that only one notification is created for the user who accept the project_join_request
-        self.assertEqual(Notification.objects.filter(
-            receiver=user,
-            notification_type=Notification.Type.PROJECT_JOIN_RESPONSE
-        ).count(), 1)
+        assert notification_qs.count() > old_count
 
     def test_project_join_request_reject(self):
         user = UserFactory.create()

--- a/apps/project/tests/test_mutations.py
+++ b/apps/project/tests/test_mutations.py
@@ -381,6 +381,12 @@ class TestProjectJoinAcceptRejectMutation(GraphQLTestCase):
         # make sure memberships is created
         self.assertIn(user2.id, ProjectMembership.objects.filter(project=project).values_list('member', flat=True))
 
+        # Make sure that only one notification is created for the user who accept the project_join_request
+        self.assertEqual(Notification.objects.filter(
+            receiver=user,
+            notification_type=Notification.Type.PROJECT_JOIN_RESPONSE
+        ).count(), 1)
+
     def test_project_join_request_reject(self):
         user = UserFactory.create()
         user2 = UserFactory.create()


### PR DESCRIPTION
Addresses xxxxxx (eg: #1 the-deep/server#1) \
Depends on xxxxxx (eg: #1 the-deep/server#1)

## Changes
- Fix for the notification triggered twice

Mention related users here if any.

## This PR doesn't introduce any:

- [x] temporary files, auto-generated files or secret keys
- [x] n+1 queries
- [x] flake8 issues
- [x] `print`
- [x] typos
- [x] unwanted comments

## This PR contains valid:

- [x] tests
- [ ] permission checks (tests here too)
- [ ] translations
