### PR TITLE
Make separate public analysis_framework query

### DIFF
--- a/apps/analysis_framework/public_schema.py
+++ b/apps/analysis_framework/public_schema.py
@@ -1,0 +1,23 @@
+from graphene_django import DjangoObjectType
+
+from utils.graphene.types import CustomDjangoListObjectType
+
+from .models import AnalysisFramework
+from .filter_set import AnalysisFrameworkGqFilterSet
+
+
+class PublicAnalysisFramework(DjangoObjectType):
+    class Meta:
+        model = AnalysisFramework
+        skip_registry = True
+        fields = (
+            'id',
+            'title'
+        )
+
+
+class PublicAnalysisFrameworkListType(CustomDjangoListObjectType):
+    class Meta:
+        model = AnalysisFramework
+        base_type = PublicAnalysisFramework
+        filterset_class = AnalysisFrameworkGqFilterSet

--- a/apps/analysis_framework/schema.py
+++ b/apps/analysis_framework/schema.py
@@ -28,6 +28,7 @@ from .enums import (
     AnalysisFrameworkRoleTypeEnum,
 )
 from .filter_set import AnalysisFrameworkGqFilterSet
+from .public_schema import PublicAnalysisFrameworkListType
 
 
 class WidgetConditionalType(graphene.ObjectType):
@@ -216,7 +217,17 @@ class Query:
             page_size_query_param='pageSize'
         )
     )
+    public_analysis_frameworks = DjangoPaginatedListObjectField(
+        PublicAnalysisFrameworkListType,
+        pagination=PageGraphqlPagination(
+            page_size_query_param='pageSize'
+        )
+    )
 
     @staticmethod
     def resolve_analysis_frameworks(root, info, **kwargs) -> QuerySet:
         return AnalysisFramework.get_for_gq(info.context.user).distinct()
+
+    @staticmethod
+    def resolve_public_analysis_frameworks(root, info, **kwargs) -> QuerySet:
+        return AnalysisFramework.objects.filter(is_private=False).distinct()

--- a/apps/analysis_framework/tests/test_schemas.py
+++ b/apps/analysis_framework/tests/test_schemas.py
@@ -65,6 +65,25 @@ class TestAnalysisFrameworkQuery(GraphQLSnapShotTestCase):
         self.assertEqual(content['data']['analysisFrameworks']['totalCount'], 3)
         self.assertIn(str(private_af.id), [d['id'] for d in results])  # Can see private project now.
 
+    def test_public_analysis_framework(self):
+        query = '''
+            query MyQuery {
+              publicAnalysisFrameworks (ordering: "id") {
+                page
+                pageSize
+                totalCount
+                results {
+                  id
+                  title
+                }
+              }
+            }
+        '''
+        AnalysisFrameworkFactory.create_batch(4, is_private=False)
+        AnalysisFrameworkFactory.create_batch(5, is_private=True)
+        content = self.query_check(query)
+        self.assertEqual(content['data']['publicAnalysisFrameworks']['totalCount'], 4, content)
+
     def test_analysis_framework(self):
         query = '''
             query MyQuery ($id: ID!) {

--- a/apps/organization/public_schema.py
+++ b/apps/organization/public_schema.py
@@ -1,0 +1,23 @@
+from graphene_django import DjangoObjectType
+
+from utils.graphene.types import CustomDjangoListObjectType
+
+from .models import Organization
+from .filters import OrganizationFilterSet
+
+
+class PublicOrganization(DjangoObjectType):
+    class Meta:
+        model = Organization
+        skip_registry = True
+        fields = (
+            'id',
+            'title'
+        )
+
+
+class PublicOrganizationListObjectType(CustomDjangoListObjectType):
+    class Meta:
+        model = Organization
+        base_type = PublicOrganization
+        filterset_class = OrganizationFilterSet

--- a/apps/organization/schema.py
+++ b/apps/organization/schema.py
@@ -10,6 +10,7 @@ from gallery.models import File
 
 from .models import Organization, OrganizationType as _OrganizationType
 from .filters import OrganizationFilterSet
+from .public_schema import PublicOrganizationListObjectType
 
 
 class OrganizationTypeType(DjangoObjectType):
@@ -78,6 +79,12 @@ class Query:
     organization = DjangoObjectField(OrganizationType)
     organizations = DjangoPaginatedListObjectField(
         OrganizationListType,
+        pagination=PageGraphqlPagination(
+            page_size_query_param='pageSize'
+        )
+    )
+    public_organizations = DjangoPaginatedListObjectField(
+        PublicOrganizationListObjectType,
         pagination=PageGraphqlPagination(
             page_size_query_param='pageSize'
         )

--- a/apps/organization/tests/test_schemas.py
+++ b/apps/organization/tests/test_schemas.py
@@ -1,12 +1,15 @@
 from utils.graphene.tests import GraphQLTestCase
 
-from organization.factories import OrganizationTypeFactory
+from organization.factories import (
+    OrganizationTypeFactory,
+    OrganizationFactory
+)
 from organization.models import OrganizationType
 from user.factories import UserFactory
 
 
 class TestOrganizationTypeQuery(GraphQLTestCase):
-    def test_lead_query(self):
+    def test_organization_type_query(self):
         query = '''
             query OrganizationType {
                 organizationTypes {
@@ -31,3 +34,20 @@ class TestOrganizationTypeQuery(GraphQLTestCase):
         content = self.query_check(query)
         self.assertEqual(len(content['data']['organizationTypes']['results']), 3, content)
         self.assertEqual(content['data']['organizationTypes']['totalCount'], 3, content)
+
+    def test_public_organizations_query(self):
+        query = '''
+            query PublicOrganizations {
+                publicOrganizations {
+                    results {
+                        id
+                        title
+                    }
+                    totalCount
+                }
+            }
+        '''
+        OrganizationFactory.create_batch(4)
+        # should be visible without authentication
+        content = self.query_check(query)
+        self.assertEqual(content['data']['publicOrganizations']['totalCount'], 4, content)

--- a/deep/settings.py
+++ b/deep/settings.py
@@ -722,6 +722,8 @@ GRAPHENE_NODES_WHITELIST = (
     'projectExploreStats',
     'publicProjects',
     'publicProjectsByRegion',
+    'publicAnalysisFrameworks',
+    'publicOrganizations',
 )
 
 # https://docs.graphene-python.org/projects/django/en/latest/settings/

--- a/schema.graphql
+++ b/schema.graphql
@@ -21,11 +21,11 @@ type AdminLevelType {
 
 type AnalysisFrameworkDetailType {
   id: ID!
+  title: String!
   createdAt: DateTime!
   modifiedAt: DateTime!
   createdBy: UserType
   modifiedBy: UserType
-  title: String!
   description: String
   isPrivate: Boolean!
   organization: OrganizationType
@@ -121,11 +121,11 @@ enum AnalysisFrameworkRoleTypeEnum {
 
 type AnalysisFrameworkType {
   id: ID!
+  title: String!
   createdAt: DateTime!
   modifiedAt: DateTime!
   createdBy: UserType
   modifiedBy: UserType
-  title: String!
   description: String
   isPrivate: Boolean!
   organization: OrganizationType
@@ -1524,6 +1524,30 @@ type ProjectVizDataType {
   publicUrl: String
 }
 
+type PublicAnalysisFramework {
+  id: ID!
+  title: String!
+}
+
+type PublicAnalysisFrameworkListType {
+  results: [PublicAnalysisFramework!]
+  totalCount: Int
+  page: Int
+  pageSize: Int
+}
+
+type PublicOrganization {
+  id: ID!
+  title: String!
+}
+
+type PublicOrganizationListObjectType {
+  results: [PublicOrganization!]
+  totalCount: Int
+  page: Int
+  pageSize: Int
+}
+
 type PublicProjectByRegionListType {
   results: [RegionWithProject!]
   totalCount: Int
@@ -1560,6 +1584,7 @@ type Query {
   regions(id: Float, code: String, title: String, public: Boolean, project: [ID], createdAt: DateTime, createdBy: [ID], modifiedAt: DateTime, modifiedBy: [ID], createdAt_Lt: Date, createdAt_Gte: Date, modifiedAt_Lt: Date, modifiedAt_Gt: Date, excludeProject: [ID], page: Int = 1, ordering: String, pageSize: Int): RegionListType
   organization(id: ID!): OrganizationType
   organizations(id: Float, search: String, page: Int = 1, ordering: String, pageSize: Int): OrganizationListType
+  publicOrganizations(id: Float, search: String, page: Int = 1, ordering: String, pageSize: Int): PublicOrganizationListObjectType
   organizationType(id: ID!): OrganizationTypeType
   organizationTypes(title: String, shortName: String, description: String, reliefWebId: Int, page: Int = 1, ordering: String, pageSize: Int): OrganizationTypeListType
   userGroup(id: ID!): UserGroupType
@@ -1569,6 +1594,7 @@ type Query {
   users(id: Float, search: String, membersExcludeProject: ID, membersExcludeFramework: ID, membersExcludeUsergroup: ID, page: Int = 1, ordering: String, pageSize: Int): UserListType
   analysisFramework(id: ID!): AnalysisFrameworkDetailType
   analysisFrameworks(id: Float, createdAt: DateTime, createdAtGte: DateTime, createdAtLte: DateTime, modifiedAt: DateTime, modifiedAtGte: DateTime, modifiedAtLte: DateTime, createdBy: [ID!], modifiedBy: [ID!], search: String, isCurrentUserMember: Boolean, page: Int = 1, ordering: String, pageSize: Int): AnalysisFrameworkListType
+  publicAnalysisFrameworks(id: Float, createdAt: DateTime, createdAtGte: DateTime, createdAtLte: DateTime, modifiedAt: DateTime, modifiedAtGte: DateTime, modifiedAtLte: DateTime, createdBy: [ID!], modifiedBy: [ID!], search: String, isCurrentUserMember: Boolean, page: Int = 1, ordering: String, pageSize: Int): PublicAnalysisFrameworkListType
   project(id: ID!): ProjectDetailType
   projects(createdAt: DateTime, createdAtGte: DateTime, createdAtLte: DateTime, modifiedAt: DateTime, modifiedAtGte: DateTime, modifiedAtLte: DateTime, createdBy: [ID!], modifiedBy: [ID!], ids: [ID!], excludeIds: [ID!], status: ProjectStatusEnum, organizations: [ID!], analysisFrameworks: [ID!], regions: [ID!], search: String, isCurrentUserMember: Boolean, hasPermissionAccess: ProjectPermission, page: Int = 1, ordering: String, pageSize: Int): ProjectListType
   recentProjects: [ProjectDetailType!]


### PR DESCRIPTION
Addresses 
- https://zube.io/deep/deep/c/4457(Explore DEEP: Analytical Framework filter is not working for Public user)
## Changes
- Separate analysis_framework and organizations query for public access

Mention related users here if any.

## This PR doesn't introduce any:

- [x] temporary files, auto-generated files or secret keys
- [x] n+1 queries
- [x] flake8 issues
- [x] `print`
- [x] typos
- [x] unwanted comments

## This PR contains valid:

- [x] tests
- [ ] permission checks (tests here too)
- [ ] translations
