### PR TITLE
Fix duplicate in public project list

### DIFF
--- a/apps/project/public_schema.py
+++ b/apps/project/public_schema.py
@@ -97,4 +97,4 @@ class PublicProjectListType(CustomDjangoListObjectType):
             'description',
             'analysis_framework_id',
             'created_at',
-        )
+        ).distinct()

--- a/apps/project/tests/test_schemas.py
+++ b/apps/project/tests/test_schemas.py
@@ -364,12 +364,13 @@ class TestProjectSchema(GraphQLTestCase):
         public_project1 = ProjectFactory.create(analysis_framework=public_analysis_framework, regions=[public_region])
         public_project2 = ProjectFactory.create(analysis_framework=public_analysis_framework, regions=[private_region])
         public_project3 = ProjectFactory.create(analysis_framework=private_analysis_framework, regions=[public_region])
+        public_project4 = ProjectFactory.create(analysis_framework=private_analysis_framework, regions=[public_region])
         private_project = ProjectFactory.create(is_private=True)
         content = self.query_check(query)
-        self.assertEqual(content['data']['publicProjects']['totalCount'], 3, content)
+        self.assertEqual(content['data']['publicProjects']['totalCount'], 4, content)
         self.assertListIds(
             content['data']['publicProjects']['results'],
-            [public_project1, public_project2, public_project3],
+            [public_project1, public_project2, public_project3, public_project4],
             content
         )
         # some checks for analysis_framework private and public


### PR DESCRIPTION
Addresses 
- Explore DEEP: Analytical Framework filter is not working for Public user(https://zube.io/deep/deep/c/4457)

## Changes
- Added distinct in queryset

Mention related users here if any.

## This PR doesn't introduce any:

- [x] temporary files, auto-generated files or secret keys
- [x] n+1 queries
- [x] flake8 issues
- [x] `print`
- [x] typos
- [x] unwanted comments

## This PR contains valid:

- [x] tests
- [ ] permission checks (tests here too)
- [ ] translations
