### PR TITLE
Allow users to clone public AF.

### DIFF
--- a/apps/analysis_framework/tests/snapshots/snap_test_schemas.py
+++ b/apps/analysis_framework/tests/snapshots/snap_test_schemas.py
@@ -10,6 +10,10 @@ snapshots = Snapshot()
 snapshots['TestAnalysisFrameworkQuery::test_analysis_framework_detail_query with-membership'] = {
     'data': {
         'analysisFramework': {
+            'allowedPermissions': [
+                'CAN_CLONE_FRAMEWORK',
+                'CAN_USE_IN_OTHER_PROJECTS',
+            ],
             'currentUserRole': 'DEFAULT',
             'description': 'Quality throughout beautiful instead ahead despite measure ago current practice nation determine operation speak.',
             'id': '1',
@@ -199,6 +203,10 @@ snapshots['TestAnalysisFrameworkQuery::test_analysis_framework_detail_query with
 snapshots['TestAnalysisFrameworkQuery::test_analysis_framework_detail_query without-membership'] = {
     'data': {
         'analysisFramework': {
+            'allowedPermissions': [
+                'CAN_CLONE_FRAMEWORK',
+                'CAN_USE_IN_OTHER_PROJECTS',
+            ],
             'currentUserRole': None,
             'description': 'Quality throughout beautiful instead ahead despite measure ago current practice nation determine operation speak.',
             'id': '1',

--- a/apps/analysis_framework/tests/test_schemas.py
+++ b/apps/analysis_framework/tests/test_schemas.py
@@ -138,6 +138,7 @@ class TestAnalysisFrameworkQuery(GraphQLSnapShotTestCase):
                 description
                 isPrivate
                 title
+                allowedPermissions
                 secondaryTagging {
                   id
                   key

--- a/deep/permissions.py
+++ b/deep/permissions.py
@@ -367,7 +367,7 @@ class AnalysisFrameworkPermissions(BasePermissions):
         Permission.CAN_USE_IN_OTHER_PROJECTS: "You don't have permission to use in other projects",
     }
 
-    DEFAULT = [
+    DEFAULT = [  # NOTE: This is also send for public AF without membership
         Permission.CAN_CLONE_FRAMEWORK,
         Permission.CAN_USE_IN_OTHER_PROJECTS,
     ]
@@ -393,5 +393,5 @@ class AnalysisFrameworkPermissions(BasePermissions):
     @classmethod
     def get_permissions(cls, role, is_public=False):
         if role is None and is_public:
-            return [cls.Permission.CAN_USE_IN_OTHER_PROJECTS]
+            return cls.DEFAULT
         return cls.PERMISSION_MAP.get(role) or []


### PR DESCRIPTION

Addresses default permission for public projects.

## Changes

* Allow users to clone public AF.

Mention related users here if any.

## This PR doesn't introduce any:

- [x] temporary files, auto-generated files or secret keys
- [x] n+1 queries
- [x] flake8 issues
- [x] `print`
- [x] typos
- [x] unwanted comments

## This PR contains valid:

- [ ] tests
- [ ] permission checks (tests here too)
- [ ] translations
