### PR TITLE
Add seperate query for EntryReviewComment

### DIFF
--- a/apps/entry/schema.py
+++ b/apps/entry/schema.py
@@ -11,7 +11,6 @@ from utils.graphene.fields import DjangoPaginatedListObjectField, DjangoListFiel
 from user_resource.schema import UserResourceMixin
 from deep.permissions import ProjectPermissions as PP
 from lead.models import Lead
-from quality_assurance.schema import EntryReviewCommentType
 from user.schema import UserType
 
 from analysis_framework.models import Widget
@@ -103,7 +102,6 @@ class EntryType(UserResourceMixin, ClientIdMixin, DjangoObjectType):
     project_labels = graphene.List(graphene.NonNull(EntryGroupLabelType))
     verified_by = DjangoListField(UserType)
     verified_by_count = graphene.Int(required=True)
-    review_comments = graphene.List(graphene.NonNull(EntryReviewCommentType))
     review_comments_count = graphene.Int(required=True)
 
     # project_labels TODO:
@@ -120,10 +118,6 @@ class EntryType(UserResourceMixin, ClientIdMixin, DjangoObjectType):
     @staticmethod
     def resolve_attributes(root, info, **kwargs):
         return info.context.dl.entry.entry_attributes.load(root.pk)
-
-    @staticmethod
-    def resolve_review_comments(root, info, **kwargs):
-        return info.context.dl.entry.review_comments.load(root.pk)
 
     @staticmethod
     def resolve_review_comments_count(root, info, **kwargs):

--- a/apps/quality_assurance/enums.py
+++ b/apps/quality_assurance/enums.py
@@ -1,3 +1,4 @@
+import graphene
 from utils.graphene.enums import (
     convert_enum_to_graphene_enum,
     get_enum_name_from_django_field,
@@ -13,3 +14,16 @@ enum_map = {
         (EntryReviewComment.comment_type, EntryReviewCommentTypeEnum),
     )
 }
+
+
+class EntryReviewCommentOrderingEnum(graphene.Enum):
+    # ASC
+    ASC_ID = 'id'
+    ASC_CREATED_AT = 'created_at'
+    ASC_COMMENT_TYPE = 'comment_type'
+    ASC_ENTRY = 'entry'
+    # DESC
+    DESC_ID = f'-{ASC_ID}'
+    DESC_CREATED_AT = f'-{ASC_CREATED_AT}'
+    DESC_COMMENT_TYPE = f'-{ASC_COMMENT_TYPE}'
+    DESC_ENTRY = f'-{ASC_ENTRY}'

--- a/apps/quality_assurance/filters.py
+++ b/apps/quality_assurance/filters.py
@@ -1,0 +1,20 @@
+import django_filters
+
+from utils.graphene.filters import (
+    IDFilter,
+    MultipleInputFilter,
+)
+from .models import EntryReviewComment
+from .enums import EntryReviewCommentOrderingEnum
+
+
+class EntryReviewCommentGQFilterSet(django_filters.FilterSet):
+    entry = IDFilter()
+    ordering = MultipleInputFilter(EntryReviewCommentOrderingEnum, method='ordering_filter')
+
+    class Meta:
+        model = EntryReviewComment
+        fields = ()
+
+    def ordering_filter(self, qs, name, value):
+        return qs.order_by(*value)

--- a/apps/quality_assurance/models.py
+++ b/apps/quality_assurance/models.py
@@ -48,6 +48,12 @@ class BaseReviewComment(models.Model):
         if last_comment_text:
             return last_comment_text.text
 
+    def save(self, *args, **kwargs):
+        super().save(*args, **kwargs)
+        # NOTE: Clear text if cached
+        if hasattr(self, 'text'):
+            del self.text
+
 
 class BaseReviewCommentText(models.Model):
     """

--- a/apps/quality_assurance/tests/test_mutations.py
+++ b/apps/quality_assurance/tests/test_mutations.py
@@ -233,6 +233,7 @@ class TestQualityAssuranceMutation(GraphQLTestCase):
         content = self._query_check(
             data, review_comment_id=comment_pk, okay=True)['data']['project']['entryReviewCommentUpdate']
         self.assertEqual(content['result']['textHistory'][0]['text'], data['text'])
+        self.assertEqual(content['result']['text'], data['text'])
         self.force_login(user2)
         self._query_check(data, review_comment_id=comment_pk, assert_for_error=True)
 

--- a/apps/quality_assurance/tests/test_schemas.py
+++ b/apps/quality_assurance/tests/test_schemas.py
@@ -29,17 +29,20 @@ class TestReviewCommentQuery(GraphQLTestCase):
                             id
                             displayName
                         }
-                        reviewComments {
+                        reviewCommentsCount
+                    }
+                    reviewComments (entry: $entryId, ordering: DESC_ID) {
+                        totalCount
+                        results {
+                            id
+                            text
                             commentType
                             createdAt
-                            id
                             mentionedUsers {
                                 displayName
                                 id
                             }
-                            text
                         }
-                        reviewCommentsCount
                     }
                 }
             }
@@ -79,14 +82,14 @@ class TestReviewCommentQuery(GraphQLTestCase):
         project.add_member(user)
         content = self.query_check(query, variables={'projectId': project.id, 'entryId': entry.id})
         self.assertEqual(content['data']['project']['entry']['reviewCommentsCount'], 2, content)
-        self.assertEqual(len(content['data']['project']['entry']['reviewComments']), 2, content)
+        self.assertEqual(content['data']['project']['reviewComments']['totalCount'], 2, content)
         self.assertListIds(
-            content['data']['project']['entry']['reviewComments'],
+            content['data']['project']['reviewComments']['results'],
             [review_comment1, review_comment2],
             content
         )
         self.assertEqual(
-            content['data']['project']['entry']['reviewComments'][1]['text'],
+            content['data']['project']['reviewComments']['results'][1]['text'],
             review_text1.text,
             content
         )
@@ -96,7 +99,7 @@ class TestReviewCommentQuery(GraphQLTestCase):
         content = self.query_check(query, variables={'projectId': project.id, 'entryId': entry.id})
         self.assertEqual(content['data']['project']['entry']['reviewCommentsCount'], 2, content)
         self.assertEqual(
-            content['data']['project']['entry']['reviewComments'][1]['text'],
+            content['data']['project']['reviewComments']['results'][1]['text'],
             review_text2.text,  # here latest text should be present
             content
         )
@@ -109,7 +112,7 @@ class TestReviewCommentQuery(GraphQLTestCase):
         # lets query for another entry
         content = self.query_check(query, variables={'projectId': project.id, 'entryId': entry1.id})
         self.assertEqual(content['data']['project']['entry']['reviewCommentsCount'], 1, content)
-        self.assertEqual(len(content['data']['project']['entry']['reviewComments']), 1, content)
+        self.assertEqual(content['data']['project']['reviewComments']['totalCount'], 1, content)
 
     def test_review_comments_project_scope_query(self):
         """

--- a/schema.graphql
+++ b/schema.graphql
@@ -551,6 +551,24 @@ input EntryReviewCommentInputType {
   mentionedUsers: [ID!]
 }
 
+type EntryReviewCommentListType {
+  results: [EntryReviewCommentType!]
+  totalCount: Int
+  page: Int
+  pageSize: Int
+}
+
+enum EntryReviewCommentOrderingEnum {
+  ASC_ID
+  ASC_CREATED_AT
+  ASC_COMMENT_TYPE
+  ASC_ENTRY
+  DESC_ID
+  DESC_CREATED_AT
+  DESC_COMMENT_TYPE
+  DESC_ENTRY
+}
+
 type EntryReviewCommentTextType {
   id: ID!
   createdAt: DateTime!
@@ -606,7 +624,6 @@ type EntryType {
   projectLabels: [EntryGroupLabelType!]
   verifiedBy: [UserType!]
   verifiedByCount: Int!
-  reviewComments: [EntryReviewCommentType!]
   reviewCommentsCount: Int!
 }
 
@@ -1262,6 +1279,7 @@ type ProjectDetailType {
   assessment(id: ID!): AssessmentType
   assessments(createdAt: DateTime, createdAtGte: DateTime, createdAtLte: DateTime, modifiedAt: DateTime, modifiedAtGte: DateTime, modifiedAtLte: DateTime, createdBy: [ID!], modifiedBy: [ID!], search: String, page: Int = 1, ordering: String, pageSize: Int): AssessmentListType
   reviewComment(id: ID!): EntryReviewCommentDetailType
+  reviewComments(entry: ID, ordering: [EntryReviewCommentOrderingEnum!], page: Int = 1, pageSize: Int): EntryReviewCommentListType
   geoAreas(ids: [ID!], search: String, page: Int = 1, ordering: String, pageSize: Int): ProjectGeoAreaListType
   export(id: ID!): UserExportType
   exports(type: [ExportDataTypeEnum!], format: [ExportFormatEnum!], status: [ExportStatusEnum!], search: String, exportedAt: DateTime, exportedAtGte: DateTime, exportedAtLte: DateTime, page: Int = 1, ordering: String, pageSize: Int): UserExportListType


### PR DESCRIPTION
Addresses EntryReviewComment Pagniation list.

## Changes

- Remove EntryReviewComment list from entry query.
- Add seperate query for EntryReviewComment

Mention related users here if any.

## This PR doesn't introduce any:

- [x] temporary files, auto-generated files or secret keys
- [x] n+1 queries
- [x] flake8 issues
- [x] `print`
- [x] typos
- [x] unwanted comments

## This PR contains valid:

- [ ] tests
- [ ] permission checks (tests here too)
- [ ] translations
