### PR TITLE
Hide user email partially

### DIFF
--- a/apps/user/schema.py
+++ b/apps/user/schema.py
@@ -15,6 +15,7 @@ from project.models import Project
 from .models import User, Feature
 from .enums import UserEmailConditionOptOutEnum
 from .filters import UserGqlFilterSet
+from .utils import generate_hidden_email
 
 
 def only_me(func):
@@ -47,6 +48,7 @@ class UserType(DjangoObjectType):
     display_picture_url = graphene.String()
     organization = graphene.String()
     language = graphene.String()
+    email_display = graphene.String(required=True)
 
     @staticmethod
     def resolve_display_picture_url(root, info, **kwargs) -> Union[str, None]:
@@ -57,6 +59,10 @@ class UserType(DjangoObjectType):
     @staticmethod
     def resolve_organization(root, info, **kwargs) -> Union[str, None]:
         return info.context.dl.user.organization.load(root.id)
+
+    @staticmethod
+    def resolve_email_display(root, info, **kwargs) -> Union[str, None]:
+        return generate_hidden_email(root.email)
 
 
 class UserMeType(DjangoObjectType):

--- a/apps/user/utils.py
+++ b/apps/user/utils.py
@@ -197,3 +197,20 @@ def send_password_changed_notification(user_id, client_ip, device_type):
         subject_template_name='password_changed/subject.txt',
         email_template_name='password_changed/email.html',
     )
+
+
+def generate_hidden_email(email):
+    email_first_text = email.split('@')[0]
+    email_last_text = email.split('@')[1]
+    len_email_first_text = len(email_first_text)
+
+    if len_email_first_text > 4:
+        email_prefix = email_first_text[:2]
+        email_suffix = email_first_text[-2:]
+
+    if 1 <= len_email_first_text <= 4:
+        email_prefix = email_first_text[:1]
+        email_suffix = email_first_text[-1:]
+
+    email_display = email_prefix + '***' + email_suffix + '@' + email_last_text
+    return email_display

--- a/schema.graphql
+++ b/schema.graphql
@@ -1926,6 +1926,7 @@ type UserType {
   displayPictureUrl: String
   organization: String
   language: String
+  emailDisplay: String!
 }
 
 input WidgetConditionalGqlInputType {


### PR DESCRIPTION
Addresses User

## Changes
- Add a function to hide email of a user

## This PR doesn't introduce any:

- [x] temporary files, auto-generated files or secret keys
- [x] n+1 queries
- [x] flake8 issues
- [x] `print`
- [x] typos
- [x] unwanted comments

## This PR contains valid:

- [x] tests
- [x] permission checks (tests here too)
- [x] translations
