### PR TITLE
Remove legacy permission check in export.

### DIFF
--- a/apps/export/tasks/tasks_entries.py
+++ b/apps/export/tasks/tasks_entries.py
@@ -43,8 +43,8 @@ def export_entries(export):
     ).qs
 
     # Prefetches
-    entries_qs = entries_qs.prefetch_related('entrygrouplabel_set')
-    entries_qs = Entry.get_exportable_queryset(entries_qs).prefetch_related(
+    entries_qs = entries_qs.prefetch_related(
+        'entrygrouplabel_set',
         'lead__authors',
         'lead__authors__organization_type',
         # Also organization parents


### PR DESCRIPTION

Addresses Duplicate entries in export.
## Changes

* Remove legacy permission check in export.

Mention related users here if any.

## This PR doesn't introduce any:

- [x] temporary files, auto-generated files or secret keys
- [x] n+1 queries
- [x] flake8 issues
- [x] `print`
- [x] typos
- [x] unwanted comments

## This PR contains valid:

- [ ] tests
- [ ] permission checks (tests here too)
- [ ] translations