### PR TITLE
Add parent_id in lead source,author filter.

### DIFF
--- a/apps/lead/tests/test_schemas.py
+++ b/apps/lead/tests/test_schemas.py
@@ -145,6 +145,7 @@ class TestLeadQuerySchema(GraphQLTestCase):
         org1 = OrganizationFactory.create(organization_type=org_type1)
         org2 = OrganizationFactory.create(organization_type=org_type2)
         org3 = OrganizationFactory.create(organization_type=org_type2)
+        org1_child = OrganizationFactory.create(organization_type=org_type2, parent=org1)
         # User with role
         user = UserFactory.create()
         member1 = UserFactory.create()
@@ -157,7 +158,7 @@ class TestLeadQuerySchema(GraphQLTestCase):
             title='Test 1',
             source_type=Lead.SourceType.TEXT,
             confidentiality=Lead.Confidentiality.CONFIDENTIAL,
-            source=org1,
+            source=org1_child,
             authors=[org1, org2],
             assignee=[member1],
             priority=Lead.Priority.HIGH,


### PR DESCRIPTION
Addresses filter issue in lead for source/author.

## Changes

* Search using parent_id and id of organization in lead.

Mention related users here if any.

## This PR doesn't introduce any:

- [ ] temporary files, auto-generated files or secret keys
- [ ] n+1 queries
- [ ] flake8 issues
- [ ] `print`
- [ ] typos
- [ ] unwanted comments

## This PR contains valid:

- [ ] tests
- [ ] permission checks (tests here too)
- [ ] translations
