### PR TITLE
Display hidden email of users in same pattern

### DIFF
--- a/apps/user/tests/test_schemas.py
+++ b/apps/user/tests/test_schemas.py
@@ -614,17 +614,17 @@ class TestUserSchema(GraphQLTestCase):
         # Query User (Success)
         content = self.query_check(query_single_user, variables={'id': str(user.id)})
         self.assertEqual(content['data']['user']['id'], str(user.id), content)
-        self.assertEqual(content['data']['user']['emailDisplay'], 'te***er@deep.com')
+        self.assertEqual(content['data']['user']['emailDisplay'], 't***r@deep.com')
 
         # Query Users (Success)
         content = self.query_check(query_all_users)
         email_display_list = [result['emailDisplay'] for result in content['data']['users']['results']]
-        self.assertTrue(set(['te***er@deep.com', 'te***r2@deep.com']).issubset(set(email_display_list)))
+        self.assertTrue(set(['t***r@deep.com', 't***2@deep.com']).issubset(set(email_display_list)))
 
     def test_generate_hidden_email(self):
         for original, expected in [
-            ('testuser1@deep.com', 'te***r1@deep.com'),
-            ('testuser2@deep.com', 'te***r2@deep.com'),
+            ('testuser1@deep.com', 't***1@deep.com'),
+            ('testuser2@deep.com', 't***2@deep.com'),
             ('abcd@deep.com', 'a***d@deep.com'),
             ('abc@deep.com', 'a***c@deep.com'),
             ('xy@deep.com', 'x***y@deep.com'),

--- a/apps/user/utils.py
+++ b/apps/user/utils.py
@@ -202,15 +202,9 @@ def send_password_changed_notification(user_id, client_ip, device_type):
 def generate_hidden_email(email):
     email_first_text = email.split('@')[0]
     email_last_text = email.split('@')[1]
-    len_email_first_text = len(email_first_text)
 
-    if len_email_first_text > 4:
-        email_prefix = email_first_text[:2]
-        email_suffix = email_first_text[-2:]
-
-    if 1 <= len_email_first_text <= 4:
-        email_prefix = email_first_text[:1]
-        email_suffix = email_first_text[-1:]
+    email_prefix = email_first_text[:1]
+    email_suffix = email_first_text[-1:]
 
     email_display = email_prefix + '***' + email_suffix + '@' + email_last_text
     return email_display


### PR DESCRIPTION
Addresses User

## Changes

- Display hidden email of all users in same pattern for any number of character before @

## This PR doesn't introduce any:

- [x] temporary files, auto-generated files or secret keys
- [x] n+1 queries
- [x] flake8 issues
- [x] `print`
- [x] typos
- [x] unwanted comments

## This PR contains valid:

- [x] tests
- [x] permission checks (tests here too)
- [x] translations
