### PR TITLE
Add redirect from private file url to lead share url.

### DIFF
--- a/apps/export/analyses/excel_exporter.py
+++ b/apps/export/analyses/excel_exporter.py
@@ -40,11 +40,6 @@ class ExcelExporter:
         for analytical_statement_entry in qs.iterator():
             entry = analytical_statement_entry.entry
             lead = entry.lead
-            entry_permalink_url = Permalink().entry(
-                entry.project_id,
-                lead.id,
-                entry.id,
-            )
             analytical_statement = analytical_statement_entry.analytical_statement
             analysis_pillar = analytical_statement.analysis_pillar
             self.analysis_sheet.append([[
@@ -55,7 +50,7 @@ class ExcelExporter:
                 analytical_statement.statement,
                 entry.id,
                 entry.excerpt,
-                entry_permalink_url,
+                Permalink.entry(entry.project_id, lead.id, entry.id),
                 lead.url,
             ]])
         return self

--- a/apps/export/entries/excel_exporter.py
+++ b/apps/export/entries/excel_exporter.py
@@ -1,16 +1,18 @@
 import logging
 from django.core.files.base import ContentFile
 
-from export.formats.xlsx import WorkBook, RowsBuilder
-from entry.models import Entry, ExportData, ProjectEntryLabel, LeadEntryGroup
-from lead.models import Lead
-from export.models import Export
 
+from deep.permalinks import Permalink
 from utils.common import (
     format_date,
     excel_column_name,
     get_valid_xml_string as xstr
 )
+from export.formats.xlsx import WorkBook, RowsBuilder
+
+from entry.models import Entry, ExportData, ProjectEntryLabel, LeadEntryGroup
+from lead.models import Lead
+from export.models import Export
 
 logger = logging.getLogger(__name__)
 
@@ -416,7 +418,7 @@ class ExcelExporter:
                 'Controlled' if entry.controlled else 'Uncontrolled',
                 f'{lead.id}',
                 lead.title,
-                lead.url or lead.generate_client_url(),
+                lead.url or Permalink.lead_share_view(lead.uuid),
                 lead.get_authoring_organizations_type_display(),
                 lead.get_authors_display(),
                 lead.get_source_display(),

--- a/apps/export/entries/report_exporter.py
+++ b/apps/export/entries/report_exporter.py
@@ -12,6 +12,7 @@ from django.db.models import (
     Q,
 )
 from docx.shared import Inches
+from deep.permalinks import Permalink
 
 from export.formats.docx import Document
 
@@ -509,10 +510,7 @@ class ReportExporter:
         if self.show_lead_entry_id:
             para.add_run('[', bold=True)
             # Add lead-entry id
-            url = (
-                f'{settings.HTTP_PROTOCOL}://{settings.DEEPER_FRONTEND_HOST}'
-                f'/permalink/projects/{entry.project_id}/leads/{entry.lead_id}/entries/{entry.id}/'
-            )
+            url = Permalink.entry(entry.project_id, entry.lead_id, entry.id),
             para.add_hyperlink(url, f"{entry.lead_id}-{entry.id}")
             para.add_run(']', bold=True)
 
@@ -574,7 +572,7 @@ class ReportExporter:
 
         source = lead.get_source_display() or 'Reference'
         author = lead.get_authors_display()
-        url = lead.url or lead.generate_client_url()
+        url = lead.url or Permalink.lead_share_view(lead.uuid),
         date = entry.lead.published_on
 
         para.add_run('(' if widget_texts_exists else ' (')
@@ -824,7 +822,7 @@ class ReportExporter:
             lead.published_on and para.add_run(f" {lead.published_on.strftime('%m/%d/%y')}. ")
 
             para = self.doc.add_paragraph()
-            url = lead.url or lead.generate_client_url()
+            url = lead.url or Permalink.lead_share_view(lead.uuid)
             if url:
                 para.add_hyperlink(url, url)
             else:

--- a/apps/gallery/views.py
+++ b/apps/gallery/views.py
@@ -21,6 +21,7 @@ from rest_framework import (
 import django_filters
 
 from deep.permissions import ModifyPermission
+from deep.permalinks import Permalink
 from project.models import Project
 from lead.models import Lead
 from entry.models import Entry
@@ -67,8 +68,10 @@ class PrivateFileView(views.APIView):
         queryset = File.objects.prefetch_related('lead_set')
         file = get_object_or_404(queryset, uuid=uuid)
         user = request.user
-        leads_pk = file.lead_set.values_list('pk', flat=True)
+        if file.lead_set.count() == 1:
+            return redirect(Permalink.lead_share_view(file.lead_set.first().uuid))
 
+        leads_pk = file.lead_set.values_list('pk', flat=True)
         if (
                 file.is_public or
                 Lead.get_for(user).filter(pk__in=leads_pk).exists() or

--- a/apps/lead/models.py
+++ b/apps/lead/models.py
@@ -161,14 +161,6 @@ class Lead(UserResource, ProjectEntityMixin):
             'attachment_id': self.attachment_id,
         }
 
-    def generate_client_url(self):
-        # This url points to client and can be used to retrieve leads
-        # TODO: Use deep/permalinks.py (being implemented in another PR)
-        return (
-            f'{settings.HTTP_PROTOCOL}://{settings.DEEPER_FRONTEND_HOST}'
-            f'/permalink/leads-uuid/{self.uuid}'
-        )
-
     def update_extraction_status(self, new_status, commit=True):
         self.extraction_status = new_status
         if commit:

--- a/apps/notification/tasks.py
+++ b/apps/notification/tasks.py
@@ -4,6 +4,7 @@ from django.db import transaction
 from entry.models import EntryComment
 from user.models import User, EmailCondition
 from user.utils import send_mail_to_user
+from deep.permalinks import Permalink
 
 from quality_assurance.models import EntryReviewComment
 
@@ -23,6 +24,7 @@ def send_entry_comment_email(user_id, comment_id):
             'assignees_display': ', '.join(
                 assignee.profile.get_display_name() for assignee in comment.assignees.all()
             ),
+            'entry_comment_client_url': Permalink.ientry_comments(comment.entry)
         },
         subject_template_name='entry/comment_notification_email.txt',
         email_template_name='entry/comment_notification_email.html',
@@ -40,6 +42,7 @@ def send_entry_review_comment_email(user_id, comment_id, notification_type):
             'CommentType': EntryReviewComment.CommentType,
             'notification_type': notification_type,
             'comment': comment,
+            'entry_comment_client_url': Permalink.ientry_comment(comment)
         },
         subject_template_name='entry/review_comment_notification_email.txt',
         email_template_name='entry/review_comment_notification_email.html',

--- a/apps/templates/entry/comment_notification_email.html
+++ b/apps/templates/entry/comment_notification_email.html
@@ -97,7 +97,7 @@
     {% endif %}
     <a
         class="comment-link"
-        href="{{protocol}}://{{client_domain}}/permalink/projects/{{comment.entry.project_id}}/leads/{{comment.entry.lead_id}}/entries/{{comment.entry_id}}/comments/"
+        href="{{entry_comment_client_url}}"
     >
         Click here to go to the comment
     </a>

--- a/apps/templates/entry/review_comment_notification_email.html
+++ b/apps/templates/entry/review_comment_notification_email.html
@@ -77,7 +77,7 @@
     <div class="actions-container">
         <a
             class="button"
-            href="{{protocol}}://{{client_domain}}/permalink/projects/{{comment.entry.project_id}}/leads/{{comment.entry.lead_id}}/entries/{{comment.entry_id}}/review-comments/{{comment.pk}}/"
+            href="{{entry_comment_client_url}}"
         >
             Go to comment
         </a>

--- a/deep/permalinks.py
+++ b/deep/permalinks.py
@@ -6,11 +6,38 @@ class Permalink:
 
     BASE_URL = f'{settings.HTTP_PROTOCOL}://{settings.DEEPER_FRONTEND_HOST}/permalink'
 
-    def project(self, _id):
-        return f'{self.BASE_URL}/projects/{_id}'
+    @classmethod
+    def project(cls, _id):
+        return f'{cls.BASE_URL}/projects/{_id}'
 
-    def lead(self, project_id, _id):
-        return f'{self.project(project_id)}/leads/{_id}'
+    @classmethod
+    def lead(cls, project_id, _id):
+        return f'{cls.project(project_id)}/leads/{_id}'
 
-    def entry(self, project_id, lead_id, _id):
-        return f'{self.lead(project_id, lead_id)}/entries/{_id}'
+    @classmethod
+    def lead_share_view(cls, uuid):
+        return f'{cls.BASE_URL}/leads-uuid/{uuid}'
+
+    @classmethod
+    def entry(cls, project_id, lead_id, _id):
+        return f'{cls.lead(project_id, lead_id)}/entries/{_id}'
+
+    @classmethod
+    def ientry(cls, entry):
+        return f'{cls.lead(entry.project_id, entry.lead_id)}/entries/{entry.id}'
+
+    @classmethod
+    def entry_comments(cls, project_id, lead_id, _id):
+        return f'{cls.entry(project_id, lead_id, _id)}/comments/'
+
+    @classmethod
+    def ientry_comments(cls, entry):
+        return f'{cls.ientry(entry)}/comments/'
+
+    @classmethod
+    def entry_comment(cls, project_id, lead_id, entry_id, _id):
+        return f'{cls.entry(project_id, lead_id, entry_id)}/review-comments/{_id}/'
+
+    @classmethod
+    def ientry_comment(cls, comment):
+        return f'{cls.ientry(comment.entry)}/review-comments/{comment.id}/'


### PR DESCRIPTION
- Using Permalink everywhere.

Mention related users here if any.

## QA Required.
- Analysis Export -> Entry permalink url.
- Entry Export (Lead permalink URL. Only for lead without website URL & Entry permalink URL)
  - Report
  - Excel
- Redirect
  - Old file url with one lead -> redirect to current lead permalink.
  - Old file url with multiple lead -> old behaviour.
- Entry review comment notification.
  - Entry comment permalink url.  

## This PR doesn't introduce any:

- [ ] temporary files, auto-generated files or secret keys
- [ ] n+1 queries
- [ ] flake8 issues
- [ ] `print`
- [ ] typos
- [ ] unwanted comments

## This PR contains valid:

- [ ] tests
- [ ] permission checks (tests here too)
- [ ] translations
