### PR TITLE
Add api for recent activity in graphql

### DIFF
--- a/apps/project/dataloaders.py
+++ b/apps/project/dataloaders.py
@@ -87,6 +87,18 @@ class OrganizationsLoader(DataLoaderWithContext):
         return Promise.resolve([_map.get(key) for key in keys])
 
 
+class UserLoader(DataLoaderWithContext):
+    def batch_load_fn(self, keys):
+        users = {user.id: user for user in User.objects.filter(id__in=keys)}
+        return Promise.resolve([users.get(user_id) for user_id in keys])
+
+
+class ProjectLoader(DataLoaderWithContext):
+    def batch_load_fn(self, keys):
+        projects = {project.id: project for project in Project.objects.filter(id__in=keys)}
+        return Promise.resolve([projects.get(project_id) for project_id in keys])
+
+
 class ProjectExploreStatsLoader(WithContextMixin):
     def get_stats(self):
         now = timezone.now()
@@ -252,3 +264,11 @@ class DataLoaders(WithContextMixin):
     @cached_property
     def project_rejected_status(self):
         return ProjectRejectStatusLoader(context=self.context)
+
+    @cached_property
+    def users(self):
+        return UserLoader(context=self.context)
+
+    @cached_property
+    def projects(self):
+        return ProjectLoader(context=self.context)

--- a/apps/project/enums.py
+++ b/apps/project/enums.py
@@ -14,6 +14,7 @@ from .models import (
     ProjectStats,
     ProjectMembership,
     ProjectUserGroupMembership,
+    RecentActivityType,
 )
 
 ProjectPermissionEnum = graphene.Enum.from_enum(PP.Permission)
@@ -25,6 +26,7 @@ ProjectStatsStatusEnum = convert_enum_to_graphene_enum(ProjectStats.Status, name
 ProjectStatsActionEnum = convert_enum_to_graphene_enum(ProjectStats.Action, name='ProjectStatsActionEnum')
 ProjectMembershipBadgeTypeEnum = convert_enum_to_graphene_enum(
     ProjectMembership.BadgeType, name='ProjectMembershipBadgeTypeEnum')
+RecentActivityTypeEnum = convert_enum_to_graphene_enum(RecentActivityType, name='RecentActivityTypeEnum')
 
 enum_map = {
     get_enum_name_from_django_field(field): enum

--- a/apps/project/models.py
+++ b/apps/project/models.py
@@ -27,6 +27,12 @@ from django.utils import timezone
 from datetime import timedelta
 
 
+class RecentActivityType(models.TextChoices):
+    LEAD = 'lead', 'Source'
+    ENTRY = 'entry', 'Entry'
+    ENTRY_COMMENT = 'entry-comment', 'Entry Comment'
+
+
 class Project(UserResource):
     """
     Project model
@@ -276,7 +282,6 @@ class Project(UserResource):
             _get_activities,
             60 * 5,  # 5min
         )
-
         return [
             {
                 field: item[index]

--- a/apps/project/schema.py
+++ b/apps/project/schema.py
@@ -25,6 +25,7 @@ from deep.serializers import URLCachedFileField
 from user_resource.schema import UserResourceMixin
 
 from user.models import User
+from user.schema import UserType
 from lead.schema import Query as LeadQuery
 from entry.schema import Query as EntryQuery
 from export.schema import Query as ExportQuery
@@ -49,6 +50,7 @@ from .models import (
     ProjectJoinRequest,
     ProjectOrganization,
     ProjectStats,
+    RecentActivityType as ActivityTypes,
 )
 from .enums import (
     ProjectPermissionEnum,
@@ -57,6 +59,7 @@ from .enums import (
     ProjectJoinRequestStatusEnum,
     ProjectOrganizationTypeEnum,
     ProjectMembershipBadgeTypeEnum,
+    RecentActivityTypeEnum,
 )
 
 from .filter_set import (
@@ -295,6 +298,26 @@ class ProjectType(UserResourceMixin, DjangoObjectType):
         return info.context.dl.project.public_geo_region.load(root.pk)
 
 
+class RecentActivityType(graphene.ObjectType):
+    id = graphene.ID(required=True)
+    created_at = graphene.DateTime()
+    project = graphene.Field(ProjectType)
+    created_by = graphene.Field(UserType)
+    type = graphene.Field(RecentActivityTypeEnum, required=True)
+    type_display = EnumDescription(required=True)
+
+    def resolve_created_by(root, info, **kwargs):
+        id = int(root['created_by'])
+        return info.context.dl.project.users.load(id)
+
+    def resolve_project(root, info, **kwargs):
+        id = int(root['project'])
+        return info.context.dl.project.projects.load(id)
+
+    def resolve_type_display(root, info, **kwargs):
+        return ActivityTypes(root['type']).label
+
+
 class AnalysisFrameworkVisibleProjectType(DjangoObjectType):
     class Meta:
         model = Project
@@ -524,6 +547,7 @@ class Query:
         )
     )
     recent_projects = graphene.List(graphene.NonNull(ProjectDetailType))
+    recent_activities = graphene.List(graphene.NonNull(RecentActivityType))
     project_explore_stats = graphene.Field(ProjectExploreStatType)
 
     # only the region for which project are public
@@ -545,6 +569,10 @@ class Query:
 
     # NOTE: This is a custom feature, see https://github.com/the-deep/graphene-django-extras
     # see: https://github.com/eamigo86/graphene-django-extras/compare/graphene-v2...the-deep:graphene-v2
+
+    @staticmethod
+    def resolve_recent_activities(root, info, **kwargs) -> QuerySet:
+        return Project.get_recent_activities(info.context.user)
 
     @staticmethod
     def resolve_projects(root, info, **kwargs) -> QuerySet:

--- a/apps/project/tests/test_schemas.py
+++ b/apps/project/tests/test_schemas.py
@@ -24,6 +24,7 @@ from analysis_framework.factories import AnalysisFrameworkFactory
 from geo.factories import RegionFactory, AdminLevelFactory, GeoAreaFactory
 from ary.factories import AssessmentTemplateFactory
 from export.factories import ExportFactory
+from quality_assurance.factories import EntryReviewCommentFactory
 
 from project.tasks import _generate_project_stats_cache
 from geo.enums import GeoAreaOrderingEnum
@@ -32,6 +33,62 @@ from .test_mutations import TestProjectGeneralMutation
 
 
 class TestProjectSchema(GraphQLTestCase):
+    def test_project_recent_activities(self):
+        query = '''
+           query MyQuery {
+                recentActivities {
+                    createdAt
+                    id
+                    type
+                    typeDisplay
+                    createdBy {
+                        displayName
+                        displayPictureUrl
+                        emailDisplay
+                        firstName
+                        id
+                        isActive
+                        language
+                        lastName
+                        organization
+                    }
+                    project {
+                        id
+                        startDate
+                        endDate
+                        description
+                        status
+                        statusDisplay
+                        title
+                    }
+                }
+            }
+        '''
+        normal_user, member_user = UserFactory.create_batch(2)
+
+        af = AnalysisFrameworkFactory.create()
+        project = ProjectFactory.create(analysis_framework=af, created_by=member_user)
+        project.add_member(member_user)
+
+        # Leads
+        lead1 = LeadFactory(project=project, created_by=member_user)
+        LeadFactory.create_batch(2, project=project, created_by=member_user)
+
+        # Entries
+        EntryFactory.create_batch(7, lead=lead1, project=project, created_by=member_user)
+        entry = EntryFactory(lead=lead1, project=project, created_by=member_user)
+
+        # Entries Comments
+        EntryReviewCommentFactory(entry=entry, created_by=member_user)
+
+        self.force_login(normal_user)
+        response = self.query_check(query)
+        self.assertEqual(len(response['data']['recentActivities']), 0)
+
+        self.force_login(member_user)
+        response = self.query_check(query)
+        self.assertEqual(len(response['data']['recentActivities']), 12)
+
     def test_project_query(self):
         """
         Test private + non-private project behaviour

--- a/schema.graphql
+++ b/schema.graphql
@@ -2103,12 +2103,28 @@ type Query {
   project(id: ID!): ProjectDetailType
   projects(createdAt: DateTime, createdAtGte: DateTime, createdAtLte: DateTime, modifiedAt: DateTime, modifiedAtGte: DateTime, modifiedAtLte: DateTime, createdBy: [ID!], modifiedBy: [ID!], ids: [ID!], excludeIds: [ID!], status: ProjectStatusEnum, organizations: [ID!], analysisFrameworks: [ID!], regions: [ID!], search: String, isCurrentUserMember: Boolean, hasPermissionAccess: ProjectPermission, page: Int = 1, ordering: String, pageSize: Int): ProjectListType
   recentProjects: [ProjectDetailType!]
+  recentActivities: [RecentActivityType!]
   projectExploreStats: ProjectExploreStatType
   projectsByRegion(projectFilter: RegionProjectFilterData, ordering: String): ProjectByRegionListType
   publicProjects(createdAt: DateTime, createdAtGte: DateTime, createdAtLte: DateTime, modifiedAt: DateTime, modifiedAtGte: DateTime, modifiedAtLte: DateTime, createdBy: [ID!], modifiedBy: [ID!], ids: [ID!], excludeIds: [ID!], status: ProjectStatusEnum, organizations: [ID!], analysisFrameworks: [ID!], regions: [ID!], search: String, isCurrentUserMember: Boolean, hasPermissionAccess: ProjectPermission, page: Int = 1, ordering: String, pageSize: Int): PublicProjectListType
   publicProjectsByRegion(projectFilter: RegionProjectFilterData, page: Int = 1, ordering: String, pageSize: Int): PublicProjectByRegionListType
   assistedTagging: AssistedTaggingRootQueryType
   _debug: DjangoDebug
+}
+
+type RecentActivityType {
+  id: ID!
+  createdAt: DateTime
+  project: ProjectType
+  createdBy: UserType
+  type: RecentActivityTypeEnum!
+  typeDisplay: EnumDescription!
+}
+
+enum RecentActivityTypeEnum {
+  LEAD
+  ENTRY
+  ENTRY_COMMENT
 }
 
 type RegionDetailType {


### PR DESCRIPTION
## Changes

- Add api for recent activity in graphql
Mention related users here if any.

## This PR doesn't introduce any:

- [x] temporary files, auto-generated files or secret keys
- [x] n+1 queries
- [x] flake8 issues
- [x] `print`
- [x] typos
- [x] unwanted comments

## This PR contains valid:

- [x] tests
- [x] permission checks (tests here too)
- [x] translations
