### PR TITLE
Add validation for duplicate project name

### DIFF
--- a/apps/project/migrations/rename_duplicate_project_name.py
+++ b/apps/project/migrations/rename_duplicate_project_name.py
@@ -1,0 +1,47 @@
+
+from django.db import migrations
+from django.db.models import Count
+
+
+def _rename_duplicate_name(Project):
+    # NOTE: Assuming there are just 4-5k projects.
+    project_title_qs = Project.objects.order_by().values('title').annotate(count=Count('id'))
+    existing_project_titles = list(  # NOTE: High memory usages
+        project_title_qs.values_list('title', flat=True).distinct()
+    )
+    existing_project_titles_lower = [title.lower() for title in existing_project_titles]
+    title_projects_map = {}
+    for title in existing_project_titles_lower:
+        projects = Project.objects.filter(title__iexact=title)
+        if projects.count() > 1:
+            title_projects_map[title] = projects
+    for title, projects in title_projects_map.items():
+        index = 0
+        for project in projects:
+            while True:  # Or for loop.
+                index += 1
+                new_title = f"{project.title} ({str(index)})"
+                if new_title.lower() not in existing_project_titles_lower:
+                    existing_project_titles_lower.append(new_title.lower())
+                    break
+            project.title = new_title
+            project.save(update_fields=('title',))
+
+
+def rename_duplicate_name(apps, schema_editor):
+    Project = apps.get_model('project', 'Project')
+    _rename_duplicate_name(Project)
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('project', '0077_merge_0076_auto_20220520_0834_0076_auto_20220524_0523'),
+    ]
+
+    operations = [
+        migrations.RunPython(
+            rename_duplicate_name,
+            reverse_code=migrations.RunPython.noop,
+        ),
+    ]

--- a/apps/project/serializers.py
+++ b/apps/project/serializers.py
@@ -854,6 +854,16 @@ class ProjectGqSerializer(DeprecatedUserResourceSerializer):
                 })
         return data
 
+    def validate_title(self, title):
+        existing_projects = Project.objects.filter(title__iexact=title)
+        if self.instance:
+            existing_projects = existing_projects.exclude(id=self.instance.id)
+        if existing_projects.exists():
+            raise serializers.ValidationError(
+                f'Project title "{title}" already exists, please provide different title',
+            )
+        return title
+
     def create(self, validated_data):
         project = super().create(validated_data)
         ProjectMembership.objects.create(

--- a/apps/project/tests/snapshots/snap_test_mutations.py
+++ b/apps/project/tests/snapshots/snap_test_mutations.py
@@ -17,9 +17,9 @@ snapshots['ProjectMutationSnapshotTest::test_project_create_mutation private-af-
         },
         'description': 'Project description 101',
         'endDate': '2021-01-01',
-        'hasPubliclyViewableConfidentialLeads': False,
-        'hasPubliclyViewableRestrictedLeads': False,
         'hasPubliclyViewableUnprotectedLeads': False,
+        'hasPubliclyViewableRestrictedLeads': False,
+        'hasPubliclyViewableConfidentialLeads': False,
         'id': '1',
         'isPrivate': True,
         'isVisualizationEnabled': False,
@@ -50,42 +50,9 @@ snapshots['ProjectMutationSnapshotTest::test_project_create_mutation public-af-p
         },
         'description': 'Project description 101',
         'endDate': '2021-01-01',
-        'hasPubliclyViewableConfidentialLeads': False,
-        'hasPubliclyViewableRestrictedLeads': False,
         'hasPubliclyViewableUnprotectedLeads': False,
-        'id': '2',
-        'isPrivate': True,
-        'isVisualizationEnabled': False,
-        'organizations': [
-            {
-                'id': '2',
-                'organization': {
-                    'id': '1',
-                    'title': 'Organization-0'
-                },
-                'organizationType': 'LEAD_ORGANIZATION',
-                'organizationTypeDisplay': 'Lead Organization'
-            }
-        ],
-        'startDate': '2020-01-01',
-        'status': 'ACTIVE',
-        'title': 'Project 1'
-    }
-}
-
-snapshots['ProjectMutationSnapshotTest::test_project_create_mutation public-af-private-project-success-2'] = {
-    'errors': None,
-    'ok': True,
-    'result': {
-        'analysisFramework': {
-            'id': '1',
-            'isPrivate': False
-        },
-        'description': 'Project description 101',
-        'endDate': '2021-01-01',
-        'hasPubliclyViewableConfidentialLeads': False,
         'hasPubliclyViewableRestrictedLeads': False,
-        'hasPubliclyViewableUnprotectedLeads': False,
+        'hasPubliclyViewableConfidentialLeads': False,
         'id': '2',
         'isPrivate': True,
         'isVisualizationEnabled': False,
@@ -106,39 +73,6 @@ snapshots['ProjectMutationSnapshotTest::test_project_create_mutation public-af-p
     }
 }
 
-snapshots['ProjectMutationSnapshotTest::test_project_create_mutation public-af-private-project-success-3'] = {
-    'errors': None,
-    'ok': True,
-    'result': {
-        'analysisFramework': {
-            'id': '1',
-            'isPrivate': False
-        },
-        'description': 'Project description 101',
-        'endDate': '2021-01-01',
-        'hasPubliclyViewableConfidentialLeads': False,
-        'hasPubliclyViewableRestrictedLeads': False,
-        'hasPubliclyViewableUnprotectedLeads': False,
-        'id': '2',
-        'isPrivate': True,
-        'isVisualizationEnabled': False,
-        'organizations': [
-            {
-                'id': '2',
-                'organization': {
-                    'id': '1',
-                    'title': 'Organization-0'
-                },
-                'organizationType': 'LEAD_ORGANIZATION',
-                'organizationTypeDisplay': 'Lead Organization'
-            }
-        ],
-        'startDate': '2020-01-01',
-        'status': 'ACTIVE',
-        'title': 'Project 3'
-    }
-}
-
 snapshots['ProjectMutationSnapshotTest::test_project_create_mutation public-af-public-project-success'] = {
     'errors': None,
     'ok': True,
@@ -149,42 +83,9 @@ snapshots['ProjectMutationSnapshotTest::test_project_create_mutation public-af-p
         },
         'description': 'Project description 101',
         'endDate': '2021-01-01',
-        'hasPubliclyViewableConfidentialLeads': False,
-        'hasPubliclyViewableRestrictedLeads': False,
         'hasPubliclyViewableUnprotectedLeads': False,
-        'id': '3',
-        'isPrivate': False,
-        'isVisualizationEnabled': False,
-        'organizations': [
-            {
-                'id': '3',
-                'organization': {
-                    'id': '1',
-                    'title': 'Organization-0'
-                },
-                'organizationType': 'LEAD_ORGANIZATION',
-                'organizationTypeDisplay': 'Lead Organization'
-            }
-        ],
-        'startDate': '2020-01-01',
-        'status': 'ACTIVE',
-        'title': 'Project 1'
-    }
-}
-
-snapshots['ProjectMutationSnapshotTest::test_project_create_mutation public-af-public-project-success-3'] = {
-    'errors': None,
-    'ok': True,
-    'result': {
-        'analysisFramework': {
-            'id': '1',
-            'isPrivate': False
-        },
-        'description': 'Project description 101',
-        'endDate': '2021-01-01',
-        'hasPubliclyViewableConfidentialLeads': False,
         'hasPubliclyViewableRestrictedLeads': False,
-        'hasPubliclyViewableUnprotectedLeads': False,
+        'hasPubliclyViewableConfidentialLeads': False,
         'id': '3',
         'isPrivate': False,
         'isVisualizationEnabled': False,

--- a/apps/project/tests/snapshots/snap_test_mutations.py
+++ b/apps/project/tests/snapshots/snap_test_mutations.py
@@ -17,9 +17,9 @@ snapshots['ProjectMutationSnapshotTest::test_project_create_mutation private-af-
         },
         'description': 'Project description 101',
         'endDate': '2021-01-01',
-        'hasPubliclyViewableUnprotectedLeads': False,
-        'hasPubliclyViewableRestrictedLeads': False,
         'hasPubliclyViewableConfidentialLeads': False,
+        'hasPubliclyViewableRestrictedLeads': False,
+        'hasPubliclyViewableUnprotectedLeads': False,
         'id': '1',
         'isPrivate': True,
         'isVisualizationEnabled': False,
@@ -50,9 +50,9 @@ snapshots['ProjectMutationSnapshotTest::test_project_create_mutation public-af-p
         },
         'description': 'Project description 101',
         'endDate': '2021-01-01',
-        'hasPubliclyViewableUnprotectedLeads': False,
-        'hasPubliclyViewableRestrictedLeads': False,
         'hasPubliclyViewableConfidentialLeads': False,
+        'hasPubliclyViewableRestrictedLeads': False,
+        'hasPubliclyViewableUnprotectedLeads': False,
         'id': '2',
         'isPrivate': True,
         'isVisualizationEnabled': False,
@@ -73,6 +73,72 @@ snapshots['ProjectMutationSnapshotTest::test_project_create_mutation public-af-p
     }
 }
 
+snapshots['ProjectMutationSnapshotTest::test_project_create_mutation public-af-private-project-success-2'] = {
+    'errors': None,
+    'ok': True,
+    'result': {
+        'analysisFramework': {
+            'id': '1',
+            'isPrivate': False
+        },
+        'description': 'Project description 101',
+        'endDate': '2021-01-01',
+        'hasPubliclyViewableConfidentialLeads': False,
+        'hasPubliclyViewableRestrictedLeads': False,
+        'hasPubliclyViewableUnprotectedLeads': False,
+        'id': '2',
+        'isPrivate': True,
+        'isVisualizationEnabled': False,
+        'organizations': [
+            {
+                'id': '2',
+                'organization': {
+                    'id': '1',
+                    'title': 'Organization-0'
+                },
+                'organizationType': 'LEAD_ORGANIZATION',
+                'organizationTypeDisplay': 'Lead Organization'
+            }
+        ],
+        'startDate': '2020-01-01',
+        'status': 'ACTIVE',
+        'title': 'Project 2'
+    }
+}
+
+snapshots['ProjectMutationSnapshotTest::test_project_create_mutation public-af-private-project-success-3'] = {
+    'errors': None,
+    'ok': True,
+    'result': {
+        'analysisFramework': {
+            'id': '1',
+            'isPrivate': False
+        },
+        'description': 'Project description 101',
+        'endDate': '2021-01-01',
+        'hasPubliclyViewableConfidentialLeads': False,
+        'hasPubliclyViewableRestrictedLeads': False,
+        'hasPubliclyViewableUnprotectedLeads': False,
+        'id': '2',
+        'isPrivate': True,
+        'isVisualizationEnabled': False,
+        'organizations': [
+            {
+                'id': '2',
+                'organization': {
+                    'id': '1',
+                    'title': 'Organization-0'
+                },
+                'organizationType': 'LEAD_ORGANIZATION',
+                'organizationTypeDisplay': 'Lead Organization'
+            }
+        ],
+        'startDate': '2020-01-01',
+        'status': 'ACTIVE',
+        'title': 'Project 3'
+    }
+}
+
 snapshots['ProjectMutationSnapshotTest::test_project_create_mutation public-af-public-project-success'] = {
     'errors': None,
     'ok': True,
@@ -83,9 +149,9 @@ snapshots['ProjectMutationSnapshotTest::test_project_create_mutation public-af-p
         },
         'description': 'Project description 101',
         'endDate': '2021-01-01',
-        'hasPubliclyViewableUnprotectedLeads': False,
-        'hasPubliclyViewableRestrictedLeads': False,
         'hasPubliclyViewableConfidentialLeads': False,
+        'hasPubliclyViewableRestrictedLeads': False,
+        'hasPubliclyViewableUnprotectedLeads': False,
         'id': '3',
         'isPrivate': False,
         'isVisualizationEnabled': False,
@@ -103,6 +169,39 @@ snapshots['ProjectMutationSnapshotTest::test_project_create_mutation public-af-p
         'startDate': '2020-01-01',
         'status': 'ACTIVE',
         'title': 'Project 1'
+    }
+}
+
+snapshots['ProjectMutationSnapshotTest::test_project_create_mutation public-af-public-project-success-3'] = {
+    'errors': None,
+    'ok': True,
+    'result': {
+        'analysisFramework': {
+            'id': '1',
+            'isPrivate': False
+        },
+        'description': 'Project description 101',
+        'endDate': '2021-01-01',
+        'hasPubliclyViewableConfidentialLeads': False,
+        'hasPubliclyViewableRestrictedLeads': False,
+        'hasPubliclyViewableUnprotectedLeads': False,
+        'id': '3',
+        'isPrivate': False,
+        'isVisualizationEnabled': False,
+        'organizations': [
+            {
+                'id': '3',
+                'organization': {
+                    'id': '1',
+                    'title': 'Organization-0'
+                },
+                'organizationType': 'LEAD_ORGANIZATION',
+                'organizationTypeDisplay': 'Lead Organization'
+            }
+        ],
+        'startDate': '2020-01-01',
+        'status': 'ACTIVE',
+        'title': 'Project 3'
     }
 }
 

--- a/apps/project/tests/test_migration.py
+++ b/apps/project/tests/test_migration.py
@@ -14,18 +14,20 @@ class TestProjectSchema(GraphQLTestCase):
         project11 = ProjectFactory(title='Japan Earthquake')
         project12 = ProjectFactory(title='Japan Hurricane')
 
+        excepted_projects_name = {
+            project1.pk: 'Ukraine war (1)',
+            project2.pk: 'Ukraine war (2)',
+            project3.pk: 'Nepal Food Crisis (1)',
+            project4.pk: 'Nepal Food Crisis (2)',
+            project5.pk: 'Iran Bombblast (1)',
+            project6.pk: 'Iran Bombblast (4)',
+            project9.pk: 'Iran Bombblast (2)',
+            project10.pk: 'Iran Bombblast (3)',
+            project11.pk: 'Japan Earthquake',
+            project12.pk: 'Japan Hurricane',
+        }
+
         _rename_duplicate_name(Project)
 
-        title_list_1 = [p.title for p in Project.objects.filter(id__in=[project1.id, project2.id])]
-        title_list_2 = [p.title for p in Project.objects.filter(id__in=[project3.id, project4.id])]
-        title_list_3 = [
-            p.title for p in Project.objects.filter(id__in=[project5.id, project6.id, project9.id, project10.id])
-        ]
-        title_list_4 = [p.title for p in Project.objects.filter(id__in=[project11.id, project12.id])]
-        self.assertEqual(title_list_1, ['Ukraine war (1)', 'Ukraine war (2)'])
-        self.assertEqual(title_list_2, ['Nepal Food Crisis (1)', 'Nepal Food Crisis (2)'])
-        self.assertEqual(
-            sorted(title_list_3),
-            sorted(['Iran Bombblast (1)', 'Iran Bombblast (2)', 'Iran Bombblast (3)', 'Iran Bombblast (4)'])
-        )
-        self.assertEqual(sorted(title_list_4), sorted(['Japan Earthquake', 'Japan Hurricane']))
+        for id, title in Project.objects.values_list('id', 'title'):
+            assert excepted_projects_name[id] == title

--- a/apps/project/tests/test_migration.py
+++ b/apps/project/tests/test_migration.py
@@ -1,0 +1,31 @@
+from utils.graphene.tests import GraphQLTestCase
+from project.factories import ProjectFactory
+from project.migrations.rename_duplicate_project_name import _rename_duplicate_name
+from project.models import Project
+
+
+class TestProjectSchema(GraphQLTestCase):
+    def test_rename_duplicate_projects(self):
+        project1, project2 = ProjectFactory.create_batch(2, title="Ukraine war")
+        project3, project4 = ProjectFactory.create_batch(2, title="Nepal Food Crisis")
+        project5, project6 = ProjectFactory.create_batch(2, title="Iran Bombblast")
+        project9 = ProjectFactory(title='Iran Bombblast (2)')
+        project10 = ProjectFactory(title='Iran Bombblast (3)')
+        project11 = ProjectFactory(title='Japan Earthquake')
+        project12 = ProjectFactory(title='Japan Hurricane')
+
+        _rename_duplicate_name(Project)
+
+        title_list_1 = [p.title for p in Project.objects.filter(id__in=[project1.id, project2.id])]
+        title_list_2 = [p.title for p in Project.objects.filter(id__in=[project3.id, project4.id])]
+        title_list_3 = [
+            p.title for p in Project.objects.filter(id__in=[project5.id, project6.id, project9.id, project10.id])
+        ]
+        title_list_4 = [p.title for p in Project.objects.filter(id__in=[project11.id, project12.id])]
+        self.assertEqual(title_list_1, ['Ukraine war (1)', 'Ukraine war (2)'])
+        self.assertEqual(title_list_2, ['Nepal Food Crisis (1)', 'Nepal Food Crisis (2)'])
+        self.assertEqual(
+            sorted(title_list_3),
+            sorted(['Iran Bombblast (1)', 'Iran Bombblast (2)', 'Iran Bombblast (3)', 'Iran Bombblast (4)'])
+        )
+        self.assertEqual(sorted(title_list_4), sorted(['Japan Earthquake', 'Japan Hurricane']))

--- a/apps/project/tests/test_mutations.py
+++ b/apps/project/tests/test_mutations.py
@@ -269,14 +269,14 @@ class ProjectMutationSnapshotTest(GraphQLSnapShotTestCase):
         minput['analysisFramework'] = str(af.pk)
         minput['isPrivate'] = True
         response = _query_check(okay=True)['data']['projectCreate']
-        self.assertMatchSnapshot(response, 'public-af-private-project-success-2')
+        self.assertMatchSnapshot(response, 'public-af-private-project-success')
 
         # Valid [public AF] + private project
         minput['title'] = "Project 3"
         minput['analysisFramework'] = str(af.pk)
         minput['isPrivate'] = False
         response = _query_check(okay=True)['data']['projectCreate']
-        self.assertMatchSnapshot(response, 'public-af-public-project-success-3')
+        self.assertMatchSnapshot(response, 'public-af-public-project-success')
 
         minput['title'] = 'Project 1'
         response = _query_check(okay=False)

--- a/apps/project/tests/test_mutations.py
+++ b/apps/project/tests/test_mutations.py
@@ -265,16 +265,21 @@ class ProjectMutationSnapshotTest(GraphQLSnapShotTestCase):
         self.assertMatchSnapshot(response, 'private-af-private-project-success')
 
         # Valid [public AF] + private project
+        minput['title'] = "Project 2"
         minput['analysisFramework'] = str(af.pk)
         minput['isPrivate'] = True
         response = _query_check(okay=True)['data']['projectCreate']
-        self.assertMatchSnapshot(response, 'public-af-private-project-success')
+        self.assertMatchSnapshot(response, 'public-af-private-project-success-2')
 
         # Valid [public AF] + private project
+        minput['title'] = "Project 3"
         minput['analysisFramework'] = str(af.pk)
         minput['isPrivate'] = False
         response = _query_check(okay=True)['data']['projectCreate']
-        self.assertMatchSnapshot(response, 'public-af-public-project-success')
+        self.assertMatchSnapshot(response, 'public-af-public-project-success-3')
+
+        minput['title'] = 'Project 1'
+        response = _query_check(okay=False)
 
     def test_project_update_mutation(self):
         query = '''


### PR DESCRIPTION
Addresses Project

## Changes
- Add validation for duplicate projects
- Add migration file to rename duplicate title projects

## This PR doesn't introduce any:

- [x] temporary files, auto-generated files or secret keys
- [x] n+1 queries
- [x] flake8 issues
- [x] `print`
- [x] typos
- [x] unwanted comments

## This PR contains valid:

- [x] tests
- [ ] permission checks (tests here too)
- [ ] translations
