### PR TITLE
Up secondary widget limit to 100

### DIFF
--- a/apps/analysis_framework/serializers.py
+++ b/apps/analysis_framework/serializers.py
@@ -300,7 +300,7 @@ def validate_items_limit(items, limit, error_message='Only %d items are allowed.
 class AfWidgetLimit():
     MAX_SECTIONS_ALLOWED = 5
     MAX_WIDGETS_ALLOWED_PER_SECTION = 10
-    MAX_WIDGETS_ALLOWED_IN_SECONDARY_TAGGING = 50
+    MAX_WIDGETS_ALLOWED_IN_SECONDARY_TAGGING = 100
 
 
 class WidgetConditionalGqlSerializer(serializers.Serializer):


### PR DESCRIPTION
Up secondary widget limit to 100
## Changes

* Up secondary widget limit to 100

Mention related users here if any.

## This PR doesn't introduce any:

- [ ] temporary files, auto-generated files or secret keys
- [ ] n+1 queries
- [ ] flake8 issues
- [ ] `print`
- [ ] typos
- [ ] unwanted comments

## This PR contains valid:

- [ ] tests
- [ ] permission checks (tests here too)
- [ ] translations
