### PR TITLE
Feature/ary protection info export

### DIFF
--- a/apps/ary/export/summary.py
+++ b/apps/ary/export/summary.py
@@ -4,6 +4,7 @@ from geo.models import GeoArea
 from ary.models import (
     MethodologyGroup,
     MethodologyOption,
+    MethodologyProtectionInfo,
     MetadataField,
     Focus,
     Sector,
@@ -63,6 +64,9 @@ def get_assessment_export_summary(assessment, planned_assessment=False):
     sectors = [x.title for x in Sector.objects.filter(template=template)]
     selected_sectors = set(methodology.get('Sectors') or [])
 
+    methodology_protection_informations = [label for _, label in MethodologyProtectionInfo.choices]
+    selected_methodology_protection_informations = set(methodology.get('Protection Info') or [])
+
     root_affected_group = AffectedGroup.objects.filter(template=template, parent=None).first()
     all_affected_groups = root_affected_group.get_children_list() if root_affected_group else []
 
@@ -98,6 +102,10 @@ def get_assessment_export_summary(assessment, planned_assessment=False):
         'sectors': {
             x: 1 if x in selected_sectors else 0
             for x in sectors
+        },
+        'protection_information_management': {
+            x: 1 if x in selected_methodology_protection_informations else 0
+            for x in methodology_protection_informations
         },
         'affected_groups': {
             x['title']: 1 if x['id'] in selected_affected_groups_ids else 0

--- a/apps/ary/models.py
+++ b/apps/ary/models.py
@@ -12,6 +12,7 @@ from .utils import (
     get_title_or_none,
     get_location_title,
     get_model_attrs_or_empty_dict,
+    get_methodology_protection_info_title,
 )
 
 from utils.common import identity, underscore_to_title
@@ -106,6 +107,17 @@ class MetadataOption(FieldOption):
 
 class MethodologyGroup(BasicTemplateEntity):
     pass
+
+
+class MethodologyProtectionInfo(models.IntegerChoices):
+    PROTECTION_MONITORING = 1, 'Protection Monitoring'
+    PROTECTION_NEEDS_ASSESSMENT = 2, 'Protection Needs Assessment'
+    CASE_MANAGEMENT = 3, 'Case Management'
+    POPULATION_DATA = 4, 'Population Data'
+    PROTECTION_RESPONSE = 5, 'Protection Response'
+    COMMUNICATING_WITH_OR_IN_AFFECTED_COMMUNITIES = 6, 'Communicating with(in) Affected Communities'
+    SECURITY_AND_SITUATIONAL_AWARENESS = 7, 'Security & Situational Awareness'
+    SECTORAL_SYSTEMS_OR_OTHER = 8, 'Sectoral Systems/Other'
 
 
 class MethodologyField(Field):
@@ -467,7 +479,8 @@ class Assessment(UserResource, ProjectEntityMixin):
             'objectives': identity,
             'sampling': identity,
             'limitations': identity,
-            'data_collection_techniques': identity
+            'data_collection_techniques': identity,
+            'protection_info': get_methodology_protection_info_title,
         }
 
         return {

--- a/apps/ary/models.py
+++ b/apps/ary/models.py
@@ -12,7 +12,7 @@ from .utils import (
     get_title_or_none,
     get_location_title,
     get_model_attrs_or_empty_dict,
-    get_methodology_protection_info_title,
+    get_integer_enum_title,
 )
 
 from utils.common import identity, underscore_to_title
@@ -480,7 +480,7 @@ class Assessment(UserResource, ProjectEntityMixin):
             'sampling': identity,
             'limitations': identity,
             'data_collection_techniques': identity,
-            'protection_info': get_methodology_protection_info_title,
+            'protection_info': get_integer_enum_title(MethodologyProtectionInfo),
         }
 
         return {

--- a/apps/ary/utils.py
+++ b/apps/ary/utils.py
@@ -2,6 +2,7 @@ from geo.models import Region, GeoArea
 from organization.models import Organization
 
 from utils.common import parse_number
+from .models import MethodologyProtectionInfo
 
 
 def get_title_or_none(Model):
@@ -18,6 +19,12 @@ def get_location_title(val):
             val['geo_json']['properties'].get('title')
     instance = GeoArea.objects.filter(id=val).first()
     return instance and instance.title
+
+
+def get_methodology_protection_info_title(val):
+    _val = int(val)
+    if _val in MethodologyProtectionInfo:
+        return MethodologyProtectionInfo(_val).label
 
 
 def get_model_attr_or_none(Model, attr):

--- a/apps/ary/utils.py
+++ b/apps/ary/utils.py
@@ -2,7 +2,6 @@ from geo.models import Region, GeoArea
 from organization.models import Organization
 
 from utils.common import parse_number
-from .models import MethodologyProtectionInfo
 
 
 def get_title_or_none(Model):
@@ -21,10 +20,12 @@ def get_location_title(val):
     return instance and instance.title
 
 
-def get_methodology_protection_info_title(val):
-    _val = int(val)
-    if _val in MethodologyProtectionInfo:
-        return MethodologyProtectionInfo(_val).label
+def get_integer_enum_title(IntegerEnum):
+    def _get_title(val):
+        _val = int(val)
+        if _val in IntegerEnum:
+            return IntegerEnum(_val).label
+    return _get_title
 
 
 def get_model_attr_or_none(Model, attr):

--- a/apps/ary/views.py
+++ b/apps/ary/views.py
@@ -20,8 +20,9 @@ from lead.views import BaseCopyView, LeadCopyView
 from .filters import AssessmentFilterSet, PlannedAssessmentFilterSet
 from .models import (
     Assessment,
-    PlannedAssessment,
     AssessmentTemplate,
+    MethodologyProtectionInfo,
+    PlannedAssessment,
 )
 from .serializers import (
     AssessmentSerializer,
@@ -185,6 +186,15 @@ class AssessmentOptionsView(views.APIView):
                     'key': project.id,
                     'value': project.title,
                 } for project in projects.distinct()
+            ]
+
+        if (fields is None or 'methodology_protection_info' in fields):
+            options['methodology_protection_info'] = [
+                {
+                    'key': value,
+                    'value': label,
+                }
+                for value, label in MethodologyProtectionInfo.choices
             ]
 
         return response.Response(options)


### PR DESCRIPTION
Addresses Export failure due to ARY.

## Changes

Add protection info in ARY.
Add cancle in Export delete.

NOTE: There are N+1 issue in the ARY Export. It needs refactoring. This PR doesn't include those.

## This PR doesn't introduce any:

- [x] temporary files, auto-generated files or secret keys
- [ ] n+1 queries
- [x] flake8 issues
- [x] `print`
- [x] typos
- [x] unwanted comments

## This PR contains valid:

- [ ] tests
- [ ] permission checks (tests here too)
- [ ] translations
