### PR TITLE
Fix organigram columns generation issue.

### DIFF
--- a/apps/analysis_framework/widgets/organigram_widget.py
+++ b/apps/analysis_framework/widgets/organigram_widget.py
@@ -57,13 +57,14 @@ def get_exportable(widget, properties):
             )
         return max(depths)
 
+    options = (properties and properties.get('options')) or {}
     return {
         'excel': {
             'type': 'multiple',
             'titles': [
                 f'{widget.title} - Level {level}'
                 for level in range(
-                    _get_depth(properties)
+                    _get_depth(options)
                 )
             ],
         },


### PR DESCRIPTION
Addresses: 
- #1147

NOTE: We need to regenerate all the columns manually after deployment.
```python3
from analysis_framework.models import Widget
from analysis_framework.utils import update_widget

widget_qs = Widget.objects.filter(
    widget_id=Widget.WidgetType.ORGANIGRAM,
    analysis_framework=1918,
)

total = widget_qs.count()
print(f'Widgets to process: {total}')

for index, widget in enumerate(widget_qs, start=1):
    print(f' - ({index}/{total})')
    update_widget(widget)
```