### PR TITLE
Feature/support multiple widgets viz

### DIFF
--- a/apps/analysis_framework/schema.py
+++ b/apps/analysis_framework/schema.py
@@ -8,7 +8,7 @@ from django.db.models import QuerySet
 
 from utils.graphene.enums import EnumDescription
 from utils.graphene.types import CustomDjangoListObjectType, ClientIdMixin, FileFieldType
-from utils.graphene.fields import DjangoPaginatedListObjectField
+from utils.graphene.fields import DjangoPaginatedListObjectField, generate_type_for_serializer
 from deep.permissions import AnalysisFrameworkPermissions as AfP
 from project.schema import AnalysisFrameworkVisibleProjectType
 from project.models import ProjectMembership
@@ -28,8 +28,15 @@ from .enums import (
     WidgetFilterTypeEnum,
     AnalysisFrameworkRoleTypeEnum,
 )
+from .serializers import AnalysisFrameworkPropertiesGqlSerializer
 from .filter_set import AnalysisFrameworkGqFilterSet
 from .public_schema import PublicAnalysisFrameworkListType
+
+
+AnalysisFrameworkPropertiesType = generate_type_for_serializer(
+    'AnalysisFrameworkPropertiesType',
+    serializer_class=AnalysisFrameworkPropertiesGqlSerializer,
+)
 
 
 class WidgetConditionalType(graphene.ObjectType):
@@ -189,6 +196,7 @@ class AnalysisFrameworkDetailType(AnalysisFrameworkType):
             AnalysisFrameworkPredictionMappingType,
         ),
     )
+    properties = graphene.NonNull(AnalysisFrameworkPropertiesType)
 
     class Meta:
         model = AnalysisFramework
@@ -196,8 +204,11 @@ class AnalysisFrameworkDetailType(AnalysisFrameworkType):
         only_fields = (
             'id', 'title', 'description', 'is_private', 'assisted_tagging_enabled', 'organization',
             'created_by', 'created_at', 'modified_by', 'modified_at',
-            'properties',
         )
+
+    @staticmethod
+    def resolve_properties(root, _):
+        return root.properties or {}
 
     @staticmethod
     def resolve_primary_tagging(root, info):

--- a/apps/analysis_framework/tests/snapshots/snap_test_mutations.py
+++ b/apps/analysis_framework/tests/snapshots/snap_test_mutations.py
@@ -439,6 +439,28 @@ snapshots['TestAnalysisFrameworkMutationSnapShotTestCase::test_analysis_framewor
             'title': 'multi-select-Widget-2',
             'version': 1,
             'widgetId': 'MULTISELECT'
+        },
+        {
+            'clientId': 'geo-widget-103-client-id',
+            'id': '7',
+            'key': 'geo-widget-103-key',
+            'order': 3,
+            'properties': {
+            },
+            'title': 'Geo',
+            'version': 1,
+            'widgetId': 'GEO'
+        },
+        {
+            'clientId': 'scale-widget-104-client-id',
+            'id': '8',
+            'key': 'scale-widget-104-key',
+            'order': 4,
+            'properties': {
+            },
+            'title': 'Scale',
+            'version': 1,
+            'widgetId': 'SCALE'
         }
     ],
     'title': 'AF (TEST)'
@@ -456,6 +478,64 @@ snapshots['TestAnalysisFrameworkMutationSnapShotTestCase::test_analysis_framewor
                         'field': 'title',
                         'messages': 'This field may not be blank.',
                         'objectErrors': None
+                    },
+                    {
+                        'arrayErrors': None,
+                        'clientId': None,
+                        'field': 'properties',
+                        'messages': None,
+                        'objectErrors': [
+                            {
+                                'arrayErrors': None,
+                                'clientId': None,
+                                'field': 'statsConfig',
+                                'messages': None,
+                                'objectErrors': [
+                                    {
+                                        'arrayErrors': None,
+                                        'clientId': None,
+                                        'field': 'geoWidget',
+                                        'messages': 'Different widget type was provided. Required: geoWidget Provided: multiselectWidget',
+                                        'objectErrors': None
+                                    },
+                                    {
+                                        'arrayErrors': None,
+                                        'clientId': None,
+                                        'field': 'severityWidget',
+                                        'messages': 'Different widget type was provided. Required: scaleWidget Provided: multiselectWidget',
+                                        'objectErrors': None
+                                    },
+                                    {
+                                        'arrayErrors': None,
+                                        'clientId': None,
+                                        'field': 'reliabilityWidget',
+                                        'messages': "Provided widget with ID: 10000001 doesn't exists",
+                                        'objectErrors': None
+                                    },
+                                    {
+                                        'arrayErrors': None,
+                                        'clientId': None,
+                                        'field': 'widget1d',
+                                        'messages': "Different widget type was provided. Required: matrix1dWidget Provided: ['multiselectWidget']",
+                                        'objectErrors': None
+                                    },
+                                    {
+                                        'arrayErrors': None,
+                                        'clientId': None,
+                                        'field': 'widget2d',
+                                        'messages': "Different widget type was provided. Required: matrix2dWidget Provided: ['multiselectWidget']",
+                                        'objectErrors': None
+                                    },
+                                    {
+                                        'arrayErrors': None,
+                                        'clientId': None,
+                                        'field': 'organigramWidgets',
+                                        'messages': "Different widget type was provided. Required: organigramWidget Provided: ['multiselectWidget']",
+                                        'objectErrors': None
+                                    }
+                                ]
+                            }
+                        ]
                     },
                     {
                         'arrayErrors': [
@@ -509,7 +589,7 @@ snapshots['TestAnalysisFrameworkMutationSnapShotTestCase::test_analysis_framewor
                                 {
                                     'clientId': 'section-2-text-101-client-id',
                                     'conditional': None,
-                                    'id': '7',
+                                    'id': '9',
                                     'key': 'section-2-text-101',
                                     'order': 1,
                                     'properties': {
@@ -566,11 +646,32 @@ snapshots['TestAnalysisFrameworkMutationSnapShotTestCase::test_analysis_framewor
                             ]
                         }
                     ],
+                    'properties': {
+                        'statsConfig': {
+                            'geoWidget': {
+                                'pk': '7'
+                            },
+                            'multiselectWidgets': [
+                                {
+                                    'pk': '6'
+                                }
+                            ],
+                            'organigramWidgets': None,
+                            'reliabilityWidget': {
+                                'pk': '8'
+                            },
+                            'severityWidget': {
+                                'pk': '8'
+                            },
+                            'widget1d': None,
+                            'widget2d': None
+                        }
+                    },
                     'secondaryTagging': [
                         {
                             'clientId': 'multi-select-widget-102-client-id',
                             'conditional': None,
-                            'id': '8',
+                            'id': '10',
                             'key': 'multi-select-widget-102-key',
                             'order': 2,
                             'properties': {
@@ -578,6 +679,30 @@ snapshots['TestAnalysisFrameworkMutationSnapShotTestCase::test_analysis_framewor
                             'title': 'multi-select-Widget-2',
                             'version': 1,
                             'widgetId': 'MULTISELECT'
+                        },
+                        {
+                            'clientId': 'geo-widget-103-client-id',
+                            'conditional': None,
+                            'id': '7',
+                            'key': 'geo-widget-103-key',
+                            'order': 3,
+                            'properties': {
+                            },
+                            'title': 'Geo',
+                            'version': 1,
+                            'widgetId': 'GEO'
+                        },
+                        {
+                            'clientId': 'scale-widget-104-client-id',
+                            'conditional': None,
+                            'id': '8',
+                            'key': 'scale-widget-104-key',
+                            'order': 4,
+                            'properties': {
+                            },
+                            'title': 'Scale',
+                            'version': 1,
+                            'widgetId': 'SCALE'
                         }
                     ],
                     'title': 'Updated AF (TEST)'
@@ -610,7 +735,7 @@ snapshots['TestAnalysisFrameworkMutationSnapShotTestCase::test_analysis_framewor
                                 {
                                     'clientId': 'section-2-text-101-client-id',
                                     'conditional': None,
-                                    'id': '10',
+                                    'id': '12',
                                     'key': 'section-2-text-101',
                                     'order': 1,
                                     'properties': {
@@ -672,6 +797,24 @@ snapshots['TestAnalysisFrameworkMutationSnapShotTestCase::test_analysis_framewor
                             ]
                         }
                     ],
+                    'properties': {
+                        'statsConfig': {
+                            'geoWidget': {
+                                'pk': '7'
+                            },
+                            'multiselectWidgets': [
+                            ],
+                            'organigramWidgets': None,
+                            'reliabilityWidget': {
+                                'pk': '8'
+                            },
+                            'severityWidget': {
+                                'pk': '8'
+                            },
+                            'widget1d': None,
+                            'widget2d': None
+                        }
+                    },
                     'secondaryTagging': [
                         {
                             'clientId': 'multi-select-widget-102-client-id',
@@ -681,7 +824,7 @@ snapshots['TestAnalysisFrameworkMutationSnapShotTestCase::test_analysis_framewor
                                 'parentWidget': '1',
                                 'parentWidgetType': 'TEXT'
                             },
-                            'id': '11',
+                            'id': '13',
                             'key': 'multi-select-widget-102-key',
                             'order': 2,
                             'properties': {
@@ -689,6 +832,30 @@ snapshots['TestAnalysisFrameworkMutationSnapShotTestCase::test_analysis_framewor
                             'title': 'multi-select-Widget-2',
                             'version': 1,
                             'widgetId': 'MULTISELECT'
+                        },
+                        {
+                            'clientId': 'geo-widget-103-client-id',
+                            'conditional': None,
+                            'id': '7',
+                            'key': 'geo-widget-103-key',
+                            'order': 3,
+                            'properties': {
+                            },
+                            'title': 'Geo',
+                            'version': 1,
+                            'widgetId': 'GEO'
+                        },
+                        {
+                            'clientId': 'scale-widget-104-client-id',
+                            'conditional': None,
+                            'id': '8',
+                            'key': 'scale-widget-104-key',
+                            'order': 4,
+                            'properties': {
+                            },
+                            'title': 'Scale',
+                            'version': 1,
+                            'widgetId': 'SCALE'
                         }
                     ],
                     'title': 'Updated AF (TEST)'
@@ -721,7 +888,7 @@ snapshots['TestAnalysisFrameworkMutationSnapShotTestCase::test_analysis_framewor
                                 {
                                     'clientId': 'section-2-text-101-client-id',
                                     'conditional': None,
-                                    'id': '12',
+                                    'id': '14',
                                     'key': 'section-2-text-101',
                                     'order': 1,
                                     'properties': {
@@ -783,11 +950,29 @@ snapshots['TestAnalysisFrameworkMutationSnapShotTestCase::test_analysis_framewor
                             ]
                         }
                     ],
+                    'properties': {
+                        'statsConfig': {
+                            'geoWidget': {
+                                'pk': '7'
+                            },
+                            'multiselectWidgets': [
+                            ],
+                            'organigramWidgets': None,
+                            'reliabilityWidget': {
+                                'pk': '8'
+                            },
+                            'severityWidget': {
+                                'pk': '8'
+                            },
+                            'widget1d': None,
+                            'widget2d': None
+                        }
+                    },
                     'secondaryTagging': [
                         {
                             'clientId': 'multi-select-widget-102-client-id',
                             'conditional': None,
-                            'id': '13',
+                            'id': '15',
                             'key': 'multi-select-widget-102-key',
                             'order': 2,
                             'properties': {
@@ -795,6 +980,30 @@ snapshots['TestAnalysisFrameworkMutationSnapShotTestCase::test_analysis_framewor
                             'title': 'multi-select-Widget-2',
                             'version': 1,
                             'widgetId': 'MULTISELECT'
+                        },
+                        {
+                            'clientId': 'geo-widget-103-client-id',
+                            'conditional': None,
+                            'id': '7',
+                            'key': 'geo-widget-103-key',
+                            'order': 3,
+                            'properties': {
+                            },
+                            'title': 'Geo',
+                            'version': 1,
+                            'widgetId': 'GEO'
+                        },
+                        {
+                            'clientId': 'scale-widget-104-client-id',
+                            'conditional': None,
+                            'id': '8',
+                            'key': 'scale-widget-104-key',
+                            'order': 4,
+                            'properties': {
+                            },
+                            'title': 'Scale',
+                            'version': 1,
+                            'widgetId': 'SCALE'
                         }
                     ],
                     'title': 'Updated AF (TEST)'

--- a/schema.graphql
+++ b/schema.graphql
@@ -30,7 +30,6 @@ type AnalysisFrameworkDetailType {
   isPrivate: Boolean!
   assistedTaggingEnabled: Boolean!
   organization: OrganizationType
-  properties: GenericScalar
   currentUserRole: AnalysisFrameworkRoleTypeEnum
   previewImage: FileFieldType
   allowedPermissions: [AnalysisFrameworkPermission!]!
@@ -41,6 +40,7 @@ type AnalysisFrameworkDetailType {
   exportables: [AnalysisFrameworkExportableType!]
   visibleProjects: [AnalysisFrameworkVisibleProjectType!]
   predictionTagsMapping: [AnalysisFrameworkPredictionMappingType!]
+  properties: AnalysisFrameworkPropertiesType!
 }
 
 type AnalysisFrameworkExportableType {
@@ -69,7 +69,7 @@ input AnalysisFrameworkInputType {
   title: String!
   description: String
   isPrivate: Boolean
-  properties: GenericScalar
+  properties: AnalysisFrameworkPropertiesGqlInputType
   organization: ID
   previewImage: Upload
   createdBy: ID
@@ -117,6 +117,42 @@ type AnalysisFrameworkPredictionMappingType {
   association: GenericScalar
   clientId: String!
   widgetType: WidgetWidgetTypeEnum!
+}
+
+input AnalysisFrameworkPropertiesGqlInputType {
+  statsConfig: AnalysisFrameworkPropertiesStatsConfigInputType
+}
+
+input AnalysisFrameworkPropertiesStatsConfigIdInputType {
+  pk: ID!
+}
+
+type AnalysisFrameworkPropertiesStatsConfigIdType {
+  pk: ID!
+}
+
+input AnalysisFrameworkPropertiesStatsConfigInputType {
+  geoWidget: AnalysisFrameworkPropertiesStatsConfigIdInputType!
+  severityWidget: AnalysisFrameworkPropertiesStatsConfigIdInputType!
+  reliabilityWidget: AnalysisFrameworkPropertiesStatsConfigIdInputType!
+  widget1d: [AnalysisFrameworkPropertiesStatsConfigIdInputType!]
+  widget2d: [AnalysisFrameworkPropertiesStatsConfigIdInputType!]
+  multiselectWidgets: [AnalysisFrameworkPropertiesStatsConfigIdInputType!]
+  organigramWidgets: [AnalysisFrameworkPropertiesStatsConfigIdInputType!]
+}
+
+type AnalysisFrameworkPropertiesStatsConfigType {
+  geoWidget: AnalysisFrameworkPropertiesStatsConfigIdType!
+  severityWidget: AnalysisFrameworkPropertiesStatsConfigIdType!
+  reliabilityWidget: AnalysisFrameworkPropertiesStatsConfigIdType!
+  widget1d: [AnalysisFrameworkPropertiesStatsConfigIdType!]
+  widget2d: [AnalysisFrameworkPropertiesStatsConfigIdType!]
+  multiselectWidgets: [AnalysisFrameworkPropertiesStatsConfigIdType!]
+  organigramWidgets: [AnalysisFrameworkPropertiesStatsConfigIdType!]
+}
+
+type AnalysisFrameworkPropertiesType {
+  statsConfig: AnalysisFrameworkPropertiesStatsConfigType
 }
 
 type AnalysisFrameworkRoleType {

--- a/utils/graphene/fields.py
+++ b/utils/graphene/fields.py
@@ -327,7 +327,7 @@ def convert_serializer_field(field, convert_choices_to_enum=True, force_optional
         field_model = field.Meta.model
         args = [global_registry.get_type_for_model(field_model)]
     elif isinstance(field, serializers.Serializer):
-        pass
+        args = [convert_serializer_to_type(field.__class__)]
     elif isinstance(field, serializers.ListSerializer):
         field = field.child
         if isinstance(field, serializers.ModelSerializer):


### PR DESCRIPTION
## Changes

- Framework Viz configuration
  - Add Type
  - Change project viz structure based to support multiple list and multiple organigram widgets.

## This PR doesn't introduce any:

- [x] temporary files, auto-generated files or secret keys
- [x] n+1 queries
- [x] flake8 issues
- [x] `print`
- [x] typos
- [x] unwanted comments

## This PR contains valid:

- [x] tests
- [x] permission checks (tests here too)
- [x] translations
