### PR TITLE
Use global date format: %d-%m-%Y

### DIFF
--- a/apps/ary/export/common.py
+++ b/apps/ary/export/common.py
@@ -1,7 +1,6 @@
 from datetime import datetime
-from utils.common import combine_dicts as _combine_dicts
+from utils.common import combine_dicts as _combine_dicts, deep_date_format
 
-DATE_FORMAT = '%d-%m-%Y'
 ISO_FORMAT = '%Y-%m-%d'
 
 
@@ -19,7 +18,7 @@ def str_to_dmy_date(datestr):
     """Uses DATE_FORMAT"""
     if not datestr:
         return None
-    return datetime.strptime(datestr, ISO_FORMAT).strftime(DATE_FORMAT)
+    return deep_date_format(datetime.strptime(datestr, ISO_FORMAT))
 
 
 def get_value(d, key, default=None):
@@ -79,7 +78,7 @@ def get_assessment_meta(assessment):
 
     return {
         'lead': {
-            'date_of_lead_publication': lead.published_on.strftime(DATE_FORMAT),
+            'date_of_lead_publication': deep_date_format(lead.published_on),
             'unique_assessment_id': assessment.id,  # TODO: something else like id hash
             'imported_by': ', '.join([user.username for user in lead.assignee.all()]),
             'lead_title': lead.title,
@@ -122,7 +121,7 @@ def get_planned_assessment_meta(assessment):
 
     return {
         'assessment': {
-            'created_date': assessment.created_at.strftime('%Y-%b-%d'),
+            'created_date': deep_date_format(assessment.created_at),
             'title': assessment.title,
             'project': assessment.project.title,
 

--- a/apps/entry/widgets/date_widget.py
+++ b/apps/entry/widgets/date_widget.py
@@ -1,6 +1,6 @@
 from dateutil.parser import parse as date_parse
 
-from utils.common import ONE_DAY
+from utils.common import ONE_DAY, deep_date_format
 from analysis_framework.widgets.date_widget import WIDGET_ID
 
 # NOTE: Please update the data version when you update the data format
@@ -12,7 +12,7 @@ def parse_date_str(value):
     date = value and date_parse(value)
     number = date and int(date.timestamp() / ONE_DAY)
     # NOTE: Please update the data version when you update the data format
-    return date and date.strftime('%d-%m-%Y'), number
+    return deep_date_format(date, fallback=None), number
 
 
 def _get_date(widget, data, widget_properties):

--- a/apps/export/assessments/excel_exporter.py
+++ b/apps/export/assessments/excel_exporter.py
@@ -4,7 +4,7 @@ from django.core.files.base import ContentFile
 
 from export.formats.xlsx import WorkBook, RowsBuilder
 from openpyxl.styles import Alignment, Font
-from utils.common import format_date, underscore_to_title
+from utils.common import deep_date_format, underscore_to_title
 
 import logging
 
@@ -118,7 +118,7 @@ class ExcelExporter:
             rows = RowsBuilder(self.split, self.group, split=False)
             lead = assessment.lead
             rows.add_value_list([
-                format_date(lead.created_at),
+                deep_date_format(lead.created_at),
                 lead.created_by.username,
                 lead.title,
                 (lead.source and lead.source.title) or lead.source_raw,

--- a/apps/export/entries/excel_exporter.py
+++ b/apps/export/entries/excel_exporter.py
@@ -4,7 +4,7 @@ from django.db import models
 
 from deep.permalinks import Permalink
 from utils.common import (
-    format_date,
+    deep_date_format,
     excel_column_name,
     get_valid_xml_string as xstr
 )
@@ -15,8 +15,6 @@ from lead.models import Lead
 from export.models import Export
 
 logger = logging.getLogger(__name__)
-
-EXPORT_DATE_FORMAT = '%m/%d/%y'
 
 
 def get_hyperlink(url, text):
@@ -227,11 +225,11 @@ class ExcelExporter:
         assignee,
     ):
         if exportable == Export.StaticColumn.LEAD_PUBLISHED_ON:
-            return format_date(lead.published_on)
+            return deep_date_format(lead.published_on)
         if exportable == Export.StaticColumn.ENTRY_CREATED_BY:
             return entry.created_by and entry.created_by.profile.get_display_name()
         elif exportable == Export.StaticColumn.ENTRY_CREATED_AT:
-            return format_date(entry.created_at.date())
+            return deep_date_format(entry.created_at)
         elif exportable == Export.StaticColumn.ENTRY_CONTROL_STATUS:
             return 'Controlled' if entry.controlled else 'Uncontrolled'
         elif exportable == Export.StaticColumn.LEAD_ID:
@@ -550,7 +548,7 @@ class ExcelExporter:
                 [[
                     lead.get_authors_display(),
                     lead.get_source_display(),
-                    (lead.published_on and lead.published_on.strftime(EXPORT_DATE_FORMAT)) or '',
+                    deep_date_format(lead.published_on),
                     get_hyperlink(lead.url, lead.title) if lead.url else lead.title,
                     lead.filtered_entry_count,
                 ]]

--- a/apps/export/entries/report_exporter.py
+++ b/apps/export/entries/report_exporter.py
@@ -13,6 +13,7 @@ from django.db.models import (
 )
 from docx.shared import Inches
 from deep.permalinks import Permalink
+from utils.common import deep_date_format
 
 from export.formats.docx import Document
 
@@ -593,9 +594,8 @@ class ReportExporter:
             para.add_run(f", {lead.title}")
 
         # Finally add date
-        # TODO: use utils.common.format_date and perhaps use information date
         if date:
-            para.add_run(f", {date.strftime('%d/%m/%Y')}")
+            para.add_run(f", {deep_date_format(date)}")
 
         para.add_run(')')
         # --- Reference End
@@ -719,7 +719,7 @@ class ReportExporter:
         """
         self.doc.add_heading(
             'DEEP Export — {} — {}'.format(
-                datetime.today().strftime('%b %d, %Y'),
+                deep_date_format(datetime.today()),
                 project.title,
             ),
             1,
@@ -818,10 +818,12 @@ class ReportExporter:
             author = lead.get_authors_display()
             source = lead.get_source_display() or 'Missing source'
 
-            author and para.add_run(f'{author}.')
+            if author:
+                para.add_run(f'{author}.')
             para.add_run(f' {source}.')
             para.add_run(f' {lead.title}.')
-            lead.published_on and para.add_run(f" {lead.published_on.strftime('%m/%d/%y')}. ")
+            if lead.published_on:
+                para.add_run(f" {deep_date_format(lead.published_on)}. ")
 
             para = self.doc.add_paragraph()
             url = lead.url or Permalink.lead_share_view(lead.uuid)

--- a/apps/export/models.py
+++ b/apps/export/models.py
@@ -3,6 +3,7 @@ from django.core.cache import cache
 from django.contrib.auth.models import User
 from django.utils import timezone
 
+from utils.common import deep_date_format
 from deep.caches import CacheKey
 from deep.celery import app as celery_app
 from project.models import Project
@@ -134,7 +135,7 @@ class Export(models.Model):
     @classmethod
     def generate_title(cls, data_type, export_type, export_format):
         file_label = cls.DEFAULT_TITLE_LABEL[(data_type, export_type, export_format)]
-        time_str = timezone.now().strftime('%Y%m%d')
+        time_str = deep_date_format(timezone.now())
         return f'{time_str} DEEP {file_label}'
 
     def get_task_id(self, clear=False):

--- a/apps/tabular/viz/renderer.py
+++ b/apps/tabular/viz/renderer.py
@@ -5,6 +5,7 @@ from datetime import datetime
 from django.conf import settings
 
 from deep.documents_types import CHART_IMAGE_MIME
+from utils.common import deep_date_format
 from gallery.models import File
 from tabular.models import Field
 from tabular.viz import (
@@ -136,7 +137,7 @@ def generate_chart(field, chart_type, images_format=['svg']):
             else:
                 params['x_params']['type'] = 'category'
                 params['x_params']['ticktext'] = [
-                    datetime.strptime(value, '%Y-%m-%dT%H:%M:%S').strftime('%d-%m-%Y')
+                    deep_date_format(datetime.strptime(value, '%Y-%m-%dT%H:%M:%S'))
                     for value in df['value']
                 ]
                 params['x_params']['tickvals'] = df['value']

--- a/apps/unified_connector/sources/unhcr_portal.py
+++ b/apps/unified_connector/sources/unhcr_portal.py
@@ -5,8 +5,10 @@ import datetime
 
 from bs4 import BeautifulSoup as Soup
 
-from .base import Source
+from utils.common import deep_date_format
 from connector.utils import ConnectorWrapper
+
+from .base import Source
 
 
 COUNTRIES_OPTIONS = [
@@ -215,8 +217,7 @@ COUNTRIES_OPTIONS = [
 
 def _format_date_or_none(iso_datestr):
     try:
-        date = datetime.datetime.strptime(iso_datestr, '%Y-%m-%d')
-        return date.strftime('%d-%m-%Y')
+        return deep_date_format(datetime.datetime.strptime(iso_datestr, '%Y-%m-%d'))
     except Exception:
         return None
 

--- a/utils/common.py
+++ b/utils/common.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 import hashlib
-from collections import Counter
-from functools import reduce
 import os
 import re
 import time
@@ -10,7 +8,10 @@ import string
 import tempfile
 import requests
 import logging
-from datetime import timedelta, datetime
+import datetime
+from typing import Union, Optional
+from collections import Counter
+from functools import reduce
 
 from django.utils.hashable import make_hashable
 from django.utils.encoding import force_str
@@ -124,20 +125,25 @@ def get_valid_xml_string(string, escape=True):
     return ''
 
 
-def format_date(date):
-    return date and date.strftime('%d-%m-%Y')
+def deep_date_format(
+    date: Optional[Union[datetime.date, datetime.datetime]],
+    fallback: Optional[str] = ''
+) -> Optional[str]:
+    if date:
+        return date.strftime('%d-%m-%Y')
+    return fallback
 
 
 def parse_date(date_str):
     try:
-        return date_str and datetime.strptime(date_str, '%d-%m-%Y')
+        return date_str and datetime.datetime.strptime(date_str, '%d-%m-%Y')
     except ValueError:
         return None
 
 
 def parse_time(time_str):
     try:
-        return time_str and datetime.strptime(time_str, '%H:%M').time()
+        return time_str and datetime.datetime.strptime(time_str, '%H:%M').time()
     except ValueError:
         return None
 
@@ -351,7 +357,7 @@ create_plotly_image.marker = dict(
 
 def get_redis_lock_ttl(lock):
     try:
-        return timedelta(seconds=redis.get_connection().ttl(lock.name))
+        return datetime.timedelta(seconds=redis.get_connection().ttl(lock.name))
     except Exception:
         pass
 


### PR DESCRIPTION
Addresses
- https://github.com/the-deep/server/issues/1269

## Changes
- Update visual format to '%d-%m-%Y'

## QA
- Entry Excel export
- Entry Report export
- ARY Export

## This PR doesn't introduce any:

- [x] temporary files, auto-generated files or secret keys
- [x] n+1 queries
- [x] flake8 issues
- [x] `print`
- [x] typos
- [x] unwanted comments

## This PR contains valid:

- [ ] tests
- [ ] permission checks (tests here too)
- [ ] translations
