### PR TITLE
Use project to filter-out leads instead of count

### DIFF
--- a/apps/deep_explore/management/commands/update_deep_explore_data.py
+++ b/apps/deep_explore/management/commands/update_deep_explore_data.py
@@ -3,6 +3,7 @@ import time
 from django.db import transaction
 from django.core.management.base import BaseCommand
 
+from deep.caches import CacheKey
 from deep_explore.tasks import (
     update_deep_explore_entries_count_by_geo_aggreagate,
     generate_public_deep_explore_snapshot,
@@ -30,6 +31,10 @@ class ShowRunTime():
 class Command(BaseCommand):
     def handle(self, **_):
         start_time = time.time()
+
+        # Try to clear cache
+        with ShowRunTime(self, 'Clear existing memory caches'):
+            print(f'Clear status: {CacheKey.ExploreDeep.clear_cache()}')
 
         # Calculate centroid for geo_areas if not already.
         with ShowRunTime(self, 'GeoCentroid Update'):

--- a/apps/deep_explore/schema.py
+++ b/apps/deep_explore/schema.py
@@ -86,6 +86,7 @@ def get_top_ten_organizations_list(
         }
         for data in leads_qs.filter(
             **{f'{lead_field}__in': organization_queryset},
+            project__in=project_qs,
         ).annotate(
             org_id=models.functions.Coalesce(
                 models.F(f'{lead_field}__parent'),
@@ -97,9 +98,7 @@ def get_top_ten_organizations_list(
             ),
         ).order_by().values('org_id', 'org_title').annotate(
             leads_count=models.Count('id', distinct=True),
-            projects_count=models.Count(
-                'project', distinct=True, filter=models.Q(project__in=project_qs)
-            ),
+            projects_count=models.Count('project', distinct=True),
         ).order_by('-leads_count', '-projects_count').values(
             'org_id',
             'org_title',

--- a/apps/deep_explore/tests.py
+++ b/apps/deep_explore/tests.py
@@ -9,6 +9,8 @@ from entry.factories import EntryFactory
 
 
 class TestDeepExploreStats(GraphQLSnapShotTestCase):
+
+    @classmethod
     def setUpClass(cls):
         user = UserFactory.create()
         user2, _ = UserFactory.create_batch(2)

--- a/deep/caches.py
+++ b/deep/caches.py
@@ -9,6 +9,14 @@ from django.core.serializers.json import DjangoJSONEncoder
 local_cache = caches['local-memory']
 
 
+def clear_cache(prefix):
+    try:
+        cache.delete_many(cache.keys(prefix))
+        return True
+    except Exception:
+        pass
+
+
 class CacheKey:
     # Redis Cache
     URL_CACHED_FILE_FIELD_KEY_FORMAT = 'url_cache_{}'
@@ -23,8 +31,8 @@ class CacheKey:
     TEMP_CUSTOM_CLIENT_ID_KEY_FORMAT = '{prefix}-client-id-mixin-{request_hash}-{instance_type}-{instance_id}'
 
     class ExploreDeep:
-        _PREFIX = 'EXPLORE-DEEP-{}-'
-        _PREFIX_STATIC = 'EXPLORE-DEEP-'
+        BASE = 'EXPLORE-DEEP-'
+        _PREFIX = BASE + '{}-'
         # Dynamic
         TOTAL_PROJECTS_COUNT = _PREFIX + 'TOTAL-PROJECTS'
         TOTAL_REGISTERED_USERS_COUNT = _PREFIX + 'TOTAL-REGISTERED-USERS'
@@ -40,7 +48,11 @@ class CacheKey:
         TOP_TEN_PROJECTS_BY_ENTRIES_LIST = _PREFIX + 'TOP-TEN-PROJECTS-BY-ENTRIES'
         TOP_TEN_PROJECTS_BY_SOURCES_LIST = _PREFIX + 'TOP-TEN-PROJECTS-BY-SOURCES'
         # Static
-        TOTAL_ENTRIES_ADDED_LAST_WEEK_COUNT = _PREFIX_STATIC + 'TOTAL_ENTRIES_ADDED_LAST_WEEK_COUNT'
+        TOTAL_ENTRIES_ADDED_LAST_WEEK_COUNT = BASE + 'TOTAL_ENTRIES_ADDED_LAST_WEEK_COUNT'
+
+        @classmethod
+        def clear_cache(cls):
+            return clear_cache(cls.BASE)
 
 
 class CacheHelper:


### PR DESCRIPTION

Addresses
- https://datafriendlyspace.slack.com/archives/C02TUAW6XDK/p1679383517087729

## Changes

* Clear memory cache on update_deep_explore_data
* Use project to filter-out leads instead of count

Mention related users here if any.

## This PR doesn't introduce any:

- [x] temporary files, auto-generated files or secret keys
- [x] n+1 queries
- [x] flake8 issues
- [x] `print`
- [x] typos
- [x] unwanted comments

## This PR contains valid:

- [ ] tests
- [ ] permission checks (tests here too)
- [ ] translations