### PR TITLE
Feature/1327-User search should show results when search for full name

### DIFF
--- a/apps/user/filters.py
+++ b/apps/user/filters.py
@@ -43,11 +43,10 @@ class UserGqlFilterSet(django_filters.FilterSet):
                 ~models.Q(groupmembership__group_id=value)
             )
         return qs
-    
+
     def filter_search(self, qs, name, value):
         if value:
             first_name, last_name = value.split(' ', 1) if ' ' in value else (value, '')
-        
         if first_name and last_name:
             qs = qs.filter(
                 models.Q(first_name__icontains=first_name) &
@@ -60,7 +59,6 @@ class UserGqlFilterSet(django_filters.FilterSet):
                 models.Q(email__icontains=value) |
                 models.Q(username__icontains=value)
             )
-
         return qs
 
     @property

--- a/apps/user/filters.py
+++ b/apps/user/filters.py
@@ -43,15 +43,24 @@ class UserGqlFilterSet(django_filters.FilterSet):
                 ~models.Q(groupmembership__group_id=value)
             )
         return qs
-
+    
     def filter_search(self, qs, name, value):
         if value:
+            first_name, last_name = value.split(' ', 1) if ' ' in value else (value, '')
+        
+        if first_name and last_name:
+            qs = qs.filter(
+                models.Q(first_name__icontains=first_name) &
+                models.Q(last_name__icontains=last_name)
+            )
+        else:
             qs = qs.filter(
                 models.Q(first_name__icontains=value) |
                 models.Q(last_name__icontains=value) |
                 models.Q(email__icontains=value) |
                 models.Q(username__icontains=value)
             )
+
         return qs
 
     @property

--- a/apps/user/filters.py
+++ b/apps/user/filters.py
@@ -2,7 +2,7 @@ import django_filters
 from django.db import models
 from django.db.models.functions import Concat
 from utils.graphene.filters import IDFilter
-from .models import Q
+
 
 from .models import User
 
@@ -55,9 +55,11 @@ class UserGqlFilterSet(django_filters.FilterSet):
                     output_field=models.CharField(),
                 )
             ).filter(
-                Q(full_name__icontains=value) |
-                Q(email__icontains=value) |
-                Q(username__icontains=value)
+                models.Q(full_name__icontains=value) |
+                models.Q(first_name__icontains=value) |
+                models.Q(last_name__icontains=value) |
+                models.Q(email__icontains=value) |
+                models.Q(username__icontains=value)
             )
         return qs
 

--- a/apps/user/tests/test_schemas.py
+++ b/apps/user/tests/test_schemas.py
@@ -587,7 +587,8 @@ class TestUserSchema(GraphQLTestCase):
             ('exclude-project-2', dict(membersExcludeProject=project2.pk), 2, [user1, user3]),
             ('exclude-af-1', dict(membersExcludeFramework=af1.pk), 1, [user3]),
             ('exclude-af-2', dict(membersExcludeFramework=af2.pk), 3, [user, user1, user3]),
-            ('search', dict(search='Guy'), 1, [user]),
+            ('search-1', dict(search='Normal'), 1, [user]),
+            ('search-2', dict(search='Guy'), 1, [user]),
         ):
             content = _query_check(filters)['data']['users']['results']
             self.assertEqual(len(content), count, (name, content))


### PR DESCRIPTION
Addresses : User search should show results when search for full name

## Changes

* Update the user filter function to allow search by full name


## This PR doesn't introduce any:

- [x] temporary files, auto-generated files or secret keys
- [x] n+1 queries
- [x] flake8 issues
- [x] `print`
- [x] typos
- [x] unwanted comments

## This PR contains valid:

- [x] tests
- [ ] permission checks (tests here too)
- [ ] translations
