### PR TITLE
Add filter is_parent for assessment-registry issues.

### DIFF
--- a/apps/analysis_framework/factories.py
+++ b/apps/analysis_framework/factories.py
@@ -8,6 +8,7 @@ from .models import (
     Widget,
     Filter,
 )
+from .widgets.store import widget_store
 
 
 class AnalysisFrameworkFactory(DjangoModelFactory):
@@ -28,7 +29,7 @@ class SectionFactory(DjangoModelFactory):
 class WidgetFactory(DjangoModelFactory):
     title = factory.Sequence(lambda n: f'Widget-{n}')
     key = factory.Sequence(lambda n: f'widget-key-{n}')
-    widget_id = fuzzy.FuzzyChoice(Widget.WidgetType.choices, getter=lambda c: c[0])
+    widget_id = fuzzy.FuzzyChoice(widget_store.keys())
     properties = {}
     version = 1
 

--- a/apps/analysis_framework/tests/snapshots/snap_test_schemas.py
+++ b/apps/analysis_framework/tests/snapshots/snap_test_schemas.py
@@ -12,7 +12,7 @@ snapshots['TestAnalysisFrameworkQuery::test_analysis_framework_detail_query with
         'analysisFramework': {
             'allowedPermissions': [
                 'CAN_CLONE_FRAMEWORK',
-                'CAN_USE_IN_OTHER_PROJECTS',
+                'CAN_USE_IN_OTHER_PROJECTS'
             ],
             'currentUserRole': 'DEFAULT',
             'description': 'Quality throughout beautiful instead ahead despite measure ago current practice nation determine operation speak.',
@@ -60,8 +60,8 @@ snapshots['TestAnalysisFrameworkQuery::test_analysis_framework_detail_query with
                             'properties': {
                             },
                             'title': 'Widget-2',
-                            'widgetId': 'DATE',
                             'version': 1,
+                            'widgetId': 'NUMBER'
                         },
                         {
                             'id': '4',
@@ -70,8 +70,8 @@ snapshots['TestAnalysisFrameworkQuery::test_analysis_framework_detail_query with
                             'properties': {
                             },
                             'title': 'Widget-1',
-                            'widgetId': 'MULTISELECT',
                             'version': 1,
+                            'widgetId': 'ORGANIGRAM'
                         },
                         {
                             'id': '3',
@@ -80,8 +80,8 @@ snapshots['TestAnalysisFrameworkQuery::test_analysis_framework_detail_query with
                             'properties': {
                             },
                             'title': 'Widget-0',
-                            'widgetId': 'TEXT',
                             'version': 1,
+                            'widgetId': 'MULTISELECT'
                         }
                     ]
                 },
@@ -92,34 +92,14 @@ snapshots['TestAnalysisFrameworkQuery::test_analysis_framework_detail_query with
                     'tooltip': 'Some tooltip info 103',
                     'widgets': [
                         {
-                            'id': '6',
-                            'key': 'widget-key-0',
-                            'order': 0,
-                            'properties': {
-                            },
-                            'title': 'Widget-0',
-                            'widgetId': 'SCALE',
-                            'version': 1,
-                        },
-                        {
                             'id': '8',
                             'key': 'widget-key-2',
                             'order': 2,
                             'properties': {
                             },
                             'title': 'Widget-2',
-                            'widgetId': 'MATRIX1D',
                             'version': 1,
-                        },
-                        {
-                            'id': '9',
-                            'key': 'widget-key-3',
-                            'order': 3,
-                            'properties': {
-                            },
-                            'title': 'Widget-3',
-                            'widgetId': 'MULTISELECT',
-                            'version': 1,
+                            'widgetId': 'DATE'
                         }
                     ]
                 },
@@ -130,14 +110,24 @@ snapshots['TestAnalysisFrameworkQuery::test_analysis_framework_detail_query with
                     'tooltip': 'Some tooltip info 101',
                     'widgets': [
                         {
+                            'id': '1',
+                            'key': 'widget-key-0',
+                            'order': 0,
+                            'properties': {
+                            },
+                            'title': 'Widget-0',
+                            'version': 1,
+                            'widgetId': 'SELECT'
+                        },
+                        {
                             'id': '2',
                             'key': 'widget-key-1',
                             'order': 1,
                             'properties': {
                             },
                             'title': 'Widget-1',
-                            'widgetId': 'SELECT',
                             'version': 1,
+                            'widgetId': 'TIME_RANGE'
                         }
                     ]
                 }
@@ -150,8 +140,8 @@ snapshots['TestAnalysisFrameworkQuery::test_analysis_framework_detail_query with
                     'properties': {
                     },
                     'title': 'Widget-3',
-                    'widgetId': 'TIME_RANGE',
                     'version': 1,
+                    'widgetId': 'SELECT'
                 },
                 {
                     'id': '12',
@@ -160,8 +150,8 @@ snapshots['TestAnalysisFrameworkQuery::test_analysis_framework_detail_query with
                     'properties': {
                     },
                     'title': 'Widget-2',
-                    'widgetId': 'MATRIX1D',
                     'version': 1,
+                    'widgetId': 'MATRIX2D'
                 },
                 {
                     'id': '11',
@@ -170,21 +160,11 @@ snapshots['TestAnalysisFrameworkQuery::test_analysis_framework_detail_query with
                     'properties': {
                     },
                     'title': 'Widget-1',
-                    'widgetId': 'GEO',
                     'version': 1,
-                },
-                {
-                    'id': '10',
-                    'key': 'widget-key-0',
-                    'order': 20,
-                    'properties': {
-                    },
-                    'title': 'Widget-0',
-                    'widgetId': 'NUMBER',
-                    'version': 1,
+                    'widgetId': 'TIME'
                 }
             ],
-            'title': 'AF-0',
+            'title': 'AF-0'
         }
     }
 }
@@ -194,7 +174,7 @@ snapshots['TestAnalysisFrameworkQuery::test_analysis_framework_detail_query with
         'analysisFramework': {
             'allowedPermissions': [
                 'CAN_CLONE_FRAMEWORK',
-                'CAN_USE_IN_OTHER_PROJECTS',
+                'CAN_USE_IN_OTHER_PROJECTS'
             ],
             'currentUserRole': None,
             'description': 'Quality throughout beautiful instead ahead despite measure ago current practice nation determine operation speak.',
@@ -216,8 +196,8 @@ snapshots['TestAnalysisFrameworkQuery::test_analysis_framework_detail_query with
                             'properties': {
                             },
                             'title': 'Widget-2',
-                            'widgetId': 'DATE',
                             'version': 1,
+                            'widgetId': 'NUMBER'
                         },
                         {
                             'id': '4',
@@ -226,8 +206,8 @@ snapshots['TestAnalysisFrameworkQuery::test_analysis_framework_detail_query with
                             'properties': {
                             },
                             'title': 'Widget-1',
-                            'widgetId': 'MULTISELECT',
                             'version': 1,
+                            'widgetId': 'ORGANIGRAM'
                         },
                         {
                             'id': '3',
@@ -236,8 +216,8 @@ snapshots['TestAnalysisFrameworkQuery::test_analysis_framework_detail_query with
                             'properties': {
                             },
                             'title': 'Widget-0',
-                            'widgetId': 'TEXT',
                             'version': 1,
+                            'widgetId': 'MULTISELECT'
                         }
                     ]
                 },
@@ -248,34 +228,14 @@ snapshots['TestAnalysisFrameworkQuery::test_analysis_framework_detail_query with
                     'tooltip': 'Some tooltip info 103',
                     'widgets': [
                         {
-                            'id': '6',
-                            'key': 'widget-key-0',
-                            'order': 0,
-                            'properties': {
-                            },
-                            'title': 'Widget-0',
-                            'widgetId': 'SCALE',
-                            'version': 1,
-                        },
-                        {
                             'id': '8',
                             'key': 'widget-key-2',
                             'order': 2,
                             'properties': {
                             },
                             'title': 'Widget-2',
-                            'widgetId': 'MATRIX1D',
                             'version': 1,
-                        },
-                        {
-                            'id': '9',
-                            'key': 'widget-key-3',
-                            'order': 3,
-                            'properties': {
-                            },
-                            'title': 'Widget-3',
-                            'widgetId': 'MULTISELECT',
-                            'version': 1,
+                            'widgetId': 'DATE'
                         }
                     ]
                 },
@@ -286,14 +246,24 @@ snapshots['TestAnalysisFrameworkQuery::test_analysis_framework_detail_query with
                     'tooltip': 'Some tooltip info 101',
                     'widgets': [
                         {
+                            'id': '1',
+                            'key': 'widget-key-0',
+                            'order': 0,
+                            'properties': {
+                            },
+                            'title': 'Widget-0',
+                            'version': 1,
+                            'widgetId': 'SELECT'
+                        },
+                        {
                             'id': '2',
                             'key': 'widget-key-1',
                             'order': 1,
                             'properties': {
                             },
                             'title': 'Widget-1',
-                            'widgetId': 'SELECT',
                             'version': 1,
+                            'widgetId': 'TIME_RANGE'
                         }
                     ]
                 }
@@ -306,8 +276,8 @@ snapshots['TestAnalysisFrameworkQuery::test_analysis_framework_detail_query with
                     'properties': {
                     },
                     'title': 'Widget-3',
-                    'widgetId': 'TIME_RANGE',
                     'version': 1,
+                    'widgetId': 'SELECT'
                 },
                 {
                     'id': '12',
@@ -316,8 +286,8 @@ snapshots['TestAnalysisFrameworkQuery::test_analysis_framework_detail_query with
                     'properties': {
                     },
                     'title': 'Widget-2',
-                    'widgetId': 'MATRIX1D',
                     'version': 1,
+                    'widgetId': 'MATRIX2D'
                 },
                 {
                     'id': '11',
@@ -326,21 +296,11 @@ snapshots['TestAnalysisFrameworkQuery::test_analysis_framework_detail_query with
                     'properties': {
                     },
                     'title': 'Widget-1',
-                    'widgetId': 'GEO',
                     'version': 1,
-                },
-                {
-                    'id': '10',
-                    'key': 'widget-key-0',
-                    'order': 20,
-                    'properties': {
-                    },
-                    'title': 'Widget-0',
-                    'widgetId': 'NUMBER',
-                    'version': 1,
+                    'widgetId': 'TIME'
                 }
             ],
-            'title': 'AF-0',
+            'title': 'AF-0'
         }
     }
 }

--- a/apps/assessment_registry/dataloaders.py
+++ b/apps/assessment_registry/dataloaders.py
@@ -39,7 +39,7 @@ class AssessmentRegistryIssueChildLoader(DataLoaderWithContext):
             'parent'
         ).annotate(
             child_count=Count(
-                'parent'
+                'id'
             )
         ).values(
             'parent',

--- a/apps/assessment_registry/filters.py
+++ b/apps/assessment_registry/filters.py
@@ -77,8 +77,10 @@ class AssessmentRegistryIssueGQFilterSet(django_filters.FilterSet):
         )
 
     def filter_is_parent(self, qs, name, value):
-        if not value:
+        if value is None:
             return qs
-        return qs.filter(
-            parent__isnull=True
-        )
+        if value:
+            # for parent
+            return qs.filter(parent__isnull=True)
+        # for child
+        return qs.filter(parent__isnull=False)

--- a/apps/assessment_registry/filters.py
+++ b/apps/assessment_registry/filters.py
@@ -63,6 +63,7 @@ class AssessmentRegistryIssueGQFilterSet(django_filters.FilterSet):
     sub_pillar = SimpleInputFilter(AssessmentRegistrySummarySubPillarTypeEnum)
     sub_dimension = SimpleInputFilter(AssessmentRegistrySummarySubDimensionTypeEnum)
     search = django_filters.CharFilter(method='filter_assessment_registry_issues')
+    is_parent = django_filters.BooleanFilter(method='filter_is_parent')
 
     class Meta:
         model = SummaryIssue
@@ -73,4 +74,11 @@ class AssessmentRegistryIssueGQFilterSet(django_filters.FilterSet):
             return qs
         return qs.filter(
             label__icontains=value
+        )
+
+    def filter_is_parent(self, qs, name, value):
+        if not value:
+            return qs
+        return qs.filter(
+            parent__isnull=True
         )

--- a/apps/assessment_registry/schema.py
+++ b/apps/assessment_registry/schema.py
@@ -28,7 +28,6 @@ from .models import (
     Answer,
     AssessmentRegistryOrganization,
 )
-from .utils import get_hierarchy_level
 from .filters import AssessmentRegistryGQFilterSet, AssessmentRegistryIssueGQFilterSet
 from .enums import (
     AssessmentRegistryCrisisTypeEnum,
@@ -273,11 +272,13 @@ class AssessmentRegistrySummaryIssueType(DjangoObjectType, UserResourceMixin):
             'full_label',
         ]
 
-    def resolve_child_count(root, info, **kwargs):
+    @staticmethod
+    def resolve_child_count(root, info, **_):
         return info.context.dl.assessment_registry.child_issues.load(root.pk)
 
-    def resolve_level(root, info, **kwargs):
-        return get_hierarchy_level(root)
+    @staticmethod
+    def resolve_level(root, info, **_):
+        return info.context.dl.assessment_registry.summary_issue_level.load(root.pk)
 
 
 class AssessmentRegistrySummaryIssueListType(CustomDjangoListObjectType):

--- a/apps/assessment_registry/schema.py
+++ b/apps/assessment_registry/schema.py
@@ -28,6 +28,7 @@ from .models import (
     Answer,
     AssessmentRegistryOrganization,
 )
+from .utils import get_hierarchy_level
 from .filters import AssessmentRegistryGQFilterSet, AssessmentRegistryIssueGQFilterSet
 from .enums import (
     AssessmentRegistryCrisisTypeEnum,
@@ -260,6 +261,8 @@ class AssessmentRegistrySummaryIssueType(DjangoObjectType, UserResourceMixin):
     sub_pillar_display = EnumDescription(source='get_sub_pillar_display', required=False)
     sub_dimension = graphene.Field(AssessmentRegistrySummarySubDimensionTypeEnum, required=False)
     sub_dimension_display = EnumDescription(source='get_sub_dimension_display', required=False)
+    child_count = graphene.Int(required=False)
+    level = graphene.Int(required=False)
 
     class Meta:
         model = SummaryIssue
@@ -269,6 +272,12 @@ class AssessmentRegistrySummaryIssueType(DjangoObjectType, UserResourceMixin):
             'label',
             'full_label',
         ]
+
+    def resolve_child_count(root, info, **kwargs):
+        return info.context.dl.assessment_registry.child_issues.load(root.pk)
+
+    def resolve_level(root, info, **kwargs):
+        return get_hierarchy_level(root)
 
 
 class AssessmentRegistrySummaryIssueListType(CustomDjangoListObjectType):

--- a/apps/assessment_registry/schema.py
+++ b/apps/assessment_registry/schema.py
@@ -260,7 +260,7 @@ class AssessmentRegistrySummaryIssueType(DjangoObjectType, UserResourceMixin):
     sub_pillar_display = EnumDescription(source='get_sub_pillar_display', required=False)
     sub_dimension = graphene.Field(AssessmentRegistrySummarySubDimensionTypeEnum, required=False)
     sub_dimension_display = EnumDescription(source='get_sub_dimension_display', required=False)
-    child_count = graphene.Int(required=False)
+    child_count = graphene.Int(required=True)
     level = graphene.Int(required=False)
 
     class Meta:

--- a/apps/entry/tests/snapshots/snap_test_mutations.py
+++ b/apps/entry/tests/snapshots/snap_test_mutations.py
@@ -16,8 +16,8 @@ snapshots['TestEntryMutation::test_entry_bulk error'] = {
                         'attributes': None,
                         'clientId': '1',
                         'droppedExcerpt': '',
-                        'entryType': 'DATA_SERIES',
-                        'excerpt': 'FfWdhjOkYRBMeyyMDHqJaRUhRIWrXPvhsBkDaUUqGWlGgOtOGMmjxWkIXHaMuFbhxZtpdpKffUFeWIXiiQEJkqHMBnIWUSmTtzQP',
+                        'entryType': 'IMAGE',
+                        'excerpt': 'fWdhjOkYRBMeyyMDHqJaRUhRIWrXPvhsBkDaUUqGWlGgOtOGMmjxWkIXHaMuFbhxZtpdpKffUFeWIXiiQEJkqHMBnIWUSmTtzQPx',
                         'highlightHidden': False,
                         'id': '1',
                         'image': {
@@ -76,7 +76,7 @@ snapshots['TestEntryMutation::test_entry_bulk success'] = {
                                 },
                                 'id': '2',
                                 'widget': '1',
-                                'widgetType': 'MATRIX2D'
+                                'widgetType': 'TIME_RANGE'
                             },
                             {
                                 'clientId': 'client-id-old-attribute-1',
@@ -84,7 +84,7 @@ snapshots['TestEntryMutation::test_entry_bulk success'] = {
                                 },
                                 'id': '1',
                                 'widget': '1',
-                                'widgetType': 'MATRIX2D'
+                                'widgetType': 'TIME_RANGE'
                             }
                         ],
                         'clientId': 'entry-old-101 (UPDATED)',
@@ -108,7 +108,7 @@ snapshots['TestEntryMutation::test_entry_bulk success'] = {
                                 },
                                 'id': '3',
                                 'widget': '1',
-                                'widgetType': 'MATRIX2D'
+                                'widgetType': 'TIME_RANGE'
                             }
                         ],
                         'clientId': 'entry-new-102',
@@ -164,7 +164,7 @@ snapshots['TestEntryMutation::test_entry_create success'] = {
                             },
                             'id': '1',
                             'widget': '1',
-                            'widgetType': 'MATRIX2D'
+                            'widgetType': 'TIME_RANGE'
                         },
                         {
                             'clientId': 'client-id-attribute-2',
@@ -172,7 +172,7 @@ snapshots['TestEntryMutation::test_entry_create success'] = {
                             },
                             'id': '2',
                             'widget': '2',
-                            'widgetType': 'SELECT'
+                            'widgetType': 'TIME'
                         },
                         {
                             'clientId': 'client-id-attribute-3',
@@ -180,7 +180,7 @@ snapshots['TestEntryMutation::test_entry_create success'] = {
                             },
                             'id': '3',
                             'widget': '3',
-                            'widgetType': 'NUMBER'
+                            'widgetType': 'GEO'
                         }
                     ],
                     'clientId': 'entry-101',
@@ -235,7 +235,7 @@ snapshots['TestEntryMutation::test_entry_update success'] = {
                             },
                             'id': '3',
                             'widget': '1',
-                            'widgetType': 'MATRIX2D'
+                            'widgetType': 'TIME_RANGE'
                         },
                         {
                             'clientId': 'client-id-attribute-1',
@@ -243,7 +243,7 @@ snapshots['TestEntryMutation::test_entry_update success'] = {
                             },
                             'id': '1',
                             'widget': '1',
-                            'widgetType': 'MATRIX2D'
+                            'widgetType': 'TIME_RANGE'
                         },
                         {
                             'clientId': 'client-id-attribute-2',
@@ -251,7 +251,7 @@ snapshots['TestEntryMutation::test_entry_update success'] = {
                             },
                             'id': '2',
                             'widget': '2',
-                            'widgetType': 'SELECT'
+                            'widgetType': 'TIME'
                         }
                     ],
                     'clientId': 'entry-101',

--- a/schema.graphql
+++ b/schema.graphql
@@ -926,7 +926,7 @@ type AssessmentRegistrySummaryIssueType {
   subPillarDisplay: EnumDescription
   subDimension: AssessmentRegistrySummarySubDimensionTypeEnum
   subDimensionDisplay: EnumDescription
-  childCount: Int
+  childCount: Int!
   level: Int
 }
 

--- a/schema.graphql
+++ b/schema.graphql
@@ -926,8 +926,8 @@ type AssessmentRegistrySummaryIssueType {
   subPillarDisplay: EnumDescription
   subDimension: AssessmentRegistrySummarySubDimensionTypeEnum
   subDimensionDisplay: EnumDescription
-  childCount: Int!
-  level: Int!
+  childCount: Int
+  level: Int
 }
 
 enum AssessmentRegistrySummaryPillarTypeEnum {

--- a/schema.graphql
+++ b/schema.graphql
@@ -3487,7 +3487,7 @@ type PublicProjectWithMembershipData {
 
 type Query {
   assessmentRegSummaryIssue(id: ID!): AssessmentRegistrySummaryIssueType
-  assessmentRegSummaryIssues(label: String, parent: ID, subPillar: AssessmentRegistrySummarySubPillarTypeEnum, subDimension: AssessmentRegistrySummarySubDimensionTypeEnum, search: String, page: Int = 1, ordering: String, pageSize: Int): AssessmentRegistrySummaryIssueListType
+  assessmentRegSummaryIssues(label: String, parent: ID, subPillar: AssessmentRegistrySummarySubPillarTypeEnum, subDimension: AssessmentRegistrySummarySubDimensionTypeEnum, search: String, isParent: Boolean, page: Int = 1, ordering: String, pageSize: Int): AssessmentRegistrySummaryIssueListType
   deepExploreStats(filter: ExploreDeepFilterInputType!): ExploreDashboardStatType
   publicDeepExploreYearlySnapshots: [PublicExploreSnapshotType!]
   publicDeepExploreGlobalSnapshots: [PublicExploreSnapshotType!]

--- a/schema.graphql
+++ b/schema.graphql
@@ -926,6 +926,8 @@ type AssessmentRegistrySummaryIssueType {
   subPillarDisplay: EnumDescription
   subDimension: AssessmentRegistrySummarySubDimensionTypeEnum
   subDimensionDisplay: EnumDescription
+  childCount: Int!
+  level: Int!
 }
 
 enum AssessmentRegistrySummaryPillarTypeEnum {


### PR DESCRIPTION
## Changes
- Add filter is_parent for assessment registry issues list.

## This PR doesn't introduce any:

- [x] temporary files, auto-generated files or secret keys
- [x] n+1 queries
- [x] flake8 issues
- [x] `print`
- [x] typos
- [x] unwanted comments

## This PR contains valid:

- [x] tests
- [ ] permission checks (tests here too)
- [ ] translations
