### PR TITLE
Check if af is not None for project visualization

### DIFF
--- a/apps/project/models.py
+++ b/apps/project/models.py
@@ -142,6 +142,7 @@ class Project(UserResource):
         is_viz_enabled = self.is_visualization_enabled
         return (
             is_viz_enabled and
+            af is not None and
             af.properties is not None and
             af.properties.get('stats_config') is not None
         )


### PR DESCRIPTION

Addresses minor bug

## Changes

* Handle when AF is not set to a project

Mention related users here if any.

## This PR doesn't introduce any:

- [x] temporary files, auto-generated files or secret keys
- [x] n+1 queries
- [x] flake8 issues
- [x] `print`
- [x] typos
- [x] unwanted comments

## This PR contains valid:

- [ ] tests
- [ ] permission checks (tests here too)
- [ ] translations