### PR TITLE
Add Lead's isAssessment & hasAssessment in EntryFilter

### DIFF
--- a/apps/deep_explore/tasks.py
+++ b/apps/deep_explore/tasks.py
@@ -197,7 +197,7 @@ def generate_public_deep_explore_snapshot():
         snapshot,
         generate_download_file=True,
     ):
-        file_content, errors = generate_query_snapshot(gql_query, {'fitler': filters})
+        file_content, errors = generate_query_snapshot(gql_query, {'filter': filters})
         if file_content is None:
             logger.error(f'Failed to generate: {errors}', exc_info=True)
             return

--- a/apps/entry/filter_set.py
+++ b/apps/entry/filter_set.py
@@ -574,6 +574,8 @@ class EntryGQFilterSet(GrapheneFilterSetMixin, UserResourceGqlFilterSet):
     lead_authoring_organization_types = IDListFilter(method='authoring_organization_types_filter')
     lead_author_organizations = IDListFilter(field_name='lead__authors')
     lead_source_organizations = IDListFilter(field_name='lead__source')
+    lead_has_assessment = django_filters.BooleanFilter(method='lead_has_assessment_filter', help_text='Lead has assessment.')
+    lead_is_assessment = django_filters.BooleanFilter(field_name='lead__is_assessment_lead')
 
     search = django_filters.CharFilter(method='search_filter')
     created_by = IDListFilter()
@@ -642,6 +644,12 @@ class EntryGQFilterSet(GrapheneFilterSetMixin, UserResourceGqlFilterSet):
         if value:
             return queryset.filter(entrygrouplabel__group__title__icontains=value)
         return queryset
+
+    def lead_has_assessment_filter(self, qs, _, value):
+        if value is None:
+            return qs
+        # TODO: We need to add new assessment module filter here after it is deployed
+        return qs.filter(lead__assessment__isnull=not value)
 
     def authoring_organization_types_filter(self, qs, name, value):
         if value:

--- a/apps/entry/filter_set.py
+++ b/apps/entry/filter_set.py
@@ -648,8 +648,7 @@ class EntryGQFilterSet(GrapheneFilterSetMixin, UserResourceGqlFilterSet):
     def lead_has_assessment_filter(self, qs, _, value):
         if value is None:
             return qs
-        # TODO: We need to add new assessment module filter here after it is deployed
-        return qs.filter(lead__assessment__isnull=not value)
+        return qs.filter(lead__assessmentregistry__isnull=not value)
 
     def authoring_organization_types_filter(self, qs, name, value):
         if value:

--- a/apps/entry/tests/test_schemas.py
+++ b/apps/entry/tests/test_schemas.py
@@ -9,6 +9,7 @@ from utils.graphene.tests import GraphQLTestCase
 from user.factories import UserFactory
 from geo.factories import RegionFactory, AdminLevelFactory, GeoAreaFactory
 from project.factories import ProjectFactory
+from ary.factories import AssessmentFactory
 from lead.factories import LeadFactory
 from entry.factories import EntryFactory, EntryAttributeFactory
 from analysis_framework.factories import AnalysisFrameworkFactory, WidgetFactory
@@ -248,6 +249,8 @@ class TestEntryQuery(GraphQLTestCase):
                 $leadPublishedOn: Date
                 $leadPublishedOnGte: Date
                 $leadPublishedOnLte: Date
+                $leadHasAssessment: Boolean
+                $leadIsAssessment: Boolean
                 $leads: [ID!]
                 $leadStatuses: [LeadStatusEnum!]
                 $leadTitle: String
@@ -282,6 +285,8 @@ class TestEntryQuery(GraphQLTestCase):
                     leadPublishedOn: $leadPublishedOn
                     leadPublishedOnGte: $leadPublishedOnGte
                     leadPublishedOnLte: $leadPublishedOnLte
+                    leadHasAssessment: $leadHasAssessment
+                    leadIsAssessment: $leadIsAssessment
                     leads: $leads
                     leadStatuses: $leadStatuses
                     leadTitle: $leadTitle
@@ -319,6 +324,7 @@ class TestEntryQuery(GraphQLTestCase):
             assignee=[member1],
             priority=Lead.Priority.HIGH,
             status=Lead.Status.IN_PROGRESS,
+            is_assessment_lead=True,
         )
         lead2 = LeadFactory.create(
             project=project,
@@ -327,6 +333,7 @@ class TestEntryQuery(GraphQLTestCase):
             assignee=[member2],
             authors=[org2, org3],
             priority=Lead.Priority.HIGH,
+            is_assessment_lead=True,
         )
         lead3 = LeadFactory.create(
             project=project,
@@ -360,6 +367,9 @@ class TestEntryQuery(GraphQLTestCase):
 
         entry4_1 = EntryFactory.create(
             project=project, analysis_framework=af, lead=lead4, entry_type=Entry.TagType.EXCERPT, controlled=False)
+
+        # For assessment filters
+        AssessmentFactory.create(project=project, lead=lead1)
 
         # create entry review comment for entry
         EntryReviewCommentFactory(entry=entry1_1, created_by=user, comment_type=EntryReviewComment.CommentType.COMMENT)
@@ -408,6 +418,10 @@ class TestEntryQuery(GraphQLTestCase):
                 {'leadStatuses': [self.genum(Lead.Status.IN_PROGRESS), self.genum(Lead.Status.TAGGED)]},
                 [entry1_1, entry2_1, entry3_1, entry4_1]
             ),
+            ({'leadIsAssessment': True}, [entry1_1, entry2_1]),
+            ({'leadIsAssessment': False}, [entry3_1, entry4_1]),
+            ({'leadHasAssessment': True}, [entry1_1]),
+            ({'leadHasAssessment': False}, [entry2_1, entry3_1, entry4_1]),
             ({'hasComment': True}, [entry1_1, entry3_1]),
             ({'hasComment': False}, [entry2_1, entry4_1]),
             ({'isVerified': True}, [entry1_1, entry2_1]),

--- a/apps/entry/tests/test_schemas.py
+++ b/apps/entry/tests/test_schemas.py
@@ -9,11 +9,11 @@ from utils.graphene.tests import GraphQLTestCase
 from user.factories import UserFactory
 from geo.factories import RegionFactory, AdminLevelFactory, GeoAreaFactory
 from project.factories import ProjectFactory
-from ary.factories import AssessmentFactory
 from lead.factories import LeadFactory
 from entry.factories import EntryFactory, EntryAttributeFactory
 from analysis_framework.factories import AnalysisFrameworkFactory, WidgetFactory
 from organization.factories import OrganizationFactory, OrganizationTypeFactory
+from assessment_registry.factories import AssessmentRegistryFactory
 from quality_assurance.factories import EntryReviewCommentFactory
 
 from lead.tests.test_schemas import TestLeadQuerySchema
@@ -369,7 +369,7 @@ class TestEntryQuery(GraphQLTestCase):
             project=project, analysis_framework=af, lead=lead4, entry_type=Entry.TagType.EXCERPT, controlled=False)
 
         # For assessment filters
-        AssessmentFactory.create(project=project, lead=lead1)
+        AssessmentRegistryFactory.create(project=project, lead=lead1)
 
         # create entry review comment for entry
         EntryReviewCommentFactory(entry=entry1_1, created_by=user, comment_type=EntryReviewComment.CommentType.COMMENT)

--- a/schema.graphql
+++ b/schema.graphql
@@ -322,7 +322,7 @@ type AnalysisPillarType {
   analyzedEntriesCount: Int!
   statements: [AnalyticalStatementType!]
   discardedEntries(tags: [DiscardedEntryTagTypeEnum!], page: Int = 1, ordering: String, pageSize: Int): AnalysisPillarDiscardedEntryListType
-  entries(id: ID, excerpt: String, controlled: Boolean, createdAt: DateTime, createdAtGte: DateTime, createdAtLte: DateTime, modifiedAt: DateTime, modifiedAtGte: DateTime, modifiedAtLte: DateTime, createdBy: [ID!], modifiedBy: [ID!], leads: [ID!], leadCreatedBy: [ID!], leadPublishedOn: Date, leadPublishedOnGte: Date, leadPublishedOnLte: Date, leadTitle: String, leadAssignees: [ID!], leadStatuses: [LeadStatusEnum!], leadPriorities: [LeadPriorityEnum!], leadConfidentialities: [LeadConfidentialityEnum!], leadAuthoringOrganizationTypes: [ID!], leadAuthorOrganizations: [ID!], leadSourceOrganizations: [ID!], search: String, entryTypes: [EntryTagTypeEnum!], projectEntryLabels: [ID!], entriesId: [ID!], geoCustomShape: String, leadGroupLabel: String, filterableData: [EntryFilterDataInputType!], hasComment: Boolean, isVerified: Boolean, discarded: Boolean, excludeEntries: [ID!], page: Int = 1, ordering: String, pageSize: Int): AnalysisPillarEntryListType
+  entries(id: ID, excerpt: String, controlled: Boolean, createdAt: DateTime, createdAtGte: DateTime, createdAtLte: DateTime, modifiedAt: DateTime, modifiedAtGte: DateTime, modifiedAtLte: DateTime, createdBy: [ID!], modifiedBy: [ID!], leads: [ID!], leadCreatedBy: [ID!], leadPublishedOn: Date, leadPublishedOnGte: Date, leadPublishedOnLte: Date, leadTitle: String, leadAssignees: [ID!], leadStatuses: [LeadStatusEnum!], leadPriorities: [LeadPriorityEnum!], leadConfidentialities: [LeadConfidentialityEnum!], leadAuthoringOrganizationTypes: [ID!], leadAuthorOrganizations: [ID!], leadSourceOrganizations: [ID!], leadHasAssessment: Boolean, leadIsAssessment: Boolean, search: String, entryTypes: [EntryTagTypeEnum!], projectEntryLabels: [ID!], entriesId: [ID!], geoCustomShape: String, leadGroupLabel: String, filterableData: [EntryFilterDataInputType!], hasComment: Boolean, isVerified: Boolean, discarded: Boolean, excludeEntries: [ID!], page: Int = 1, ordering: String, pageSize: Int): AnalysisPillarEntryListType
 }
 
 input AnalysisPillarUpdateInputType {
@@ -3168,6 +3168,8 @@ input EntriesFilterDataInputType {
   leadAuthoringOrganizationTypes: [ID!]
   leadAuthorOrganizations: [ID!]
   leadSourceOrganizations: [ID!]
+  leadHasAssessment: Boolean
+  leadIsAssessment: Boolean
   search: String
   entryTypes: [EntryTagTypeEnum!]
   projectEntryLabels: [ID!]
@@ -3207,6 +3209,8 @@ type EntriesFilterDataType {
   leadPublishedOnGte: Date
   leadPublishedOnLte: Date
   leadTitle: String
+  leadHasAssessment: Boolean
+  leadIsAssessment: Boolean
   search: String
   geoCustomShape: String
   leadGroupLabel: String
@@ -4516,7 +4520,7 @@ type ProjectDetailType {
   export(id: ID!): UserExportType
   exports(type: [ExportDataTypeEnum!], format: [ExportFormatEnum!], status: [ExportStatusEnum!], search: String, exportedAt: DateTime, exportedAtGte: DateTime, exportedAtLte: DateTime, page: Int = 1, ordering: String, pageSize: Int): UserExportListType
   entry(id: ID!): EntryType
-  entries(id: ID, excerpt: String, controlled: Boolean, createdAt: DateTime, createdAtGte: DateTime, createdAtLte: DateTime, modifiedAt: DateTime, modifiedAtGte: DateTime, modifiedAtLte: DateTime, createdBy: [ID!], modifiedBy: [ID!], leads: [ID!], leadCreatedBy: [ID!], leadPublishedOn: Date, leadPublishedOnGte: Date, leadPublishedOnLte: Date, leadTitle: String, leadAssignees: [ID!], leadStatuses: [LeadStatusEnum!], leadPriorities: [LeadPriorityEnum!], leadConfidentialities: [LeadConfidentialityEnum!], leadAuthoringOrganizationTypes: [ID!], leadAuthorOrganizations: [ID!], leadSourceOrganizations: [ID!], search: String, entryTypes: [EntryTagTypeEnum!], projectEntryLabels: [ID!], entriesId: [ID!], geoCustomShape: String, leadGroupLabel: String, filterableData: [EntryFilterDataInputType!], hasComment: Boolean, isVerified: Boolean, page: Int = 1, ordering: String, pageSize: Int): EntryListType
+  entries(id: ID, excerpt: String, controlled: Boolean, createdAt: DateTime, createdAtGte: DateTime, createdAtLte: DateTime, modifiedAt: DateTime, modifiedAtGte: DateTime, modifiedAtLte: DateTime, createdBy: [ID!], modifiedBy: [ID!], leads: [ID!], leadCreatedBy: [ID!], leadPublishedOn: Date, leadPublishedOnGte: Date, leadPublishedOnLte: Date, leadTitle: String, leadAssignees: [ID!], leadStatuses: [LeadStatusEnum!], leadPriorities: [LeadPriorityEnum!], leadConfidentialities: [LeadConfidentialityEnum!], leadAuthoringOrganizationTypes: [ID!], leadAuthorOrganizations: [ID!], leadSourceOrganizations: [ID!], leadHasAssessment: Boolean, leadIsAssessment: Boolean, search: String, entryTypes: [EntryTagTypeEnum!], projectEntryLabels: [ID!], entriesId: [ID!], geoCustomShape: String, leadGroupLabel: String, filterableData: [EntryFilterDataInputType!], hasComment: Boolean, isVerified: Boolean, page: Int = 1, ordering: String, pageSize: Int): EntryListType
   lead(id: ID!): LeadDetailType
   leads(text: String, url: String, createdAt: DateTime, createdAtGte: DateTime, createdAtLte: DateTime, modifiedAt: DateTime, modifiedAtGte: DateTime, modifiedAtLte: DateTime, createdBy: [ID!], modifiedBy: [ID!], ids: [ID!], excludeProvidedLeadsId: Boolean, sourceTypes: [LeadSourceTypeEnum!], priorities: [LeadPriorityEnum!], confidentiality: LeadConfidentialityEnum, statuses: [LeadStatusEnum!], extractionStatus: LeadExtractionStatusEnum, assignees: [ID!], authoringOrganizationTypes: [ID!], authorOrganizations: [ID!], sourceOrganizations: [ID!], hasEntries: Boolean, hasAssessment: Boolean, isAssessment: Boolean, entriesFilterData: EntriesFilterDataInputType, search: String, publishedOn: Date, publishedOnGte: Date, publishedOnLte: Date, emmEntities: String, emmKeywords: String, emmRiskFactors: String, hasDuplicates: Boolean, duplicatesOf: ID, ordering: [LeadOrderingEnum!], page: Int = 1, pageSize: Int): LeadListType
   leadGroup(id: ID!): LeadGroupType


### PR DESCRIPTION
Addresses
- https://github.com/the-deep/server/issues/1395
- https://deep-of.sentry.io/issues/4615292471/?environment=prod&project=1223295&query=is%3Aunresolved+filter&referrer=issue-stream&statsPeriod=30d&stream_index=1

## Changes

Add new filters in EntryFilter
- leadIsAssessment
- leadHasAssessment
- Fix typo


## This PR doesn't introduce any:

- [x] temporary files, auto-generated files or secret keys
- [x] n+1 queries
- [x] flake8 issues
- [x] `print`
- [x] typos
- [x] unwanted comments

## This PR contains valid:

- [x] tests
- [ ] permission checks (tests here too)
- [ ] translations