### PR TITLE
Fix: Add Remaining Lead Extract task to Celery task registry

### DIFF
--- a/apps/lead/tasks.py
+++ b/apps/lead/tasks.py
@@ -43,6 +43,7 @@ def generate_previews(lead_ids=None):
         extract_from_lead.apply_async((lead_id,), countdown=1)
 
 
+@shared_task
 @redis_lock('remaining_lead_extract', 60 * 60 * 0.5)
 def remaining_lead_extract():
     """

--- a/apps/unified_connector/tasks.py
+++ b/apps/unified_connector/tasks.py
@@ -59,7 +59,9 @@ def trigger_connector_sources(max_execution_time, threshold, limit):
     # Trigger connector leads
     for unified_connector_id in processed_unified_connectors:
         UnifiedConnectorLeadHandler.send_trigger_request_to_extractor(
-            ConnectorLead.objects.filter(connectorsourcelead__source__unified_connector=unified_connector_id)
+            ConnectorLead.objects.filter(
+                connectorsourcelead__source__unified_connector=unified_connector_id
+            )
         )
 
 
@@ -86,7 +88,7 @@ def schedule_trigger_heavy_unified_connectors():
 
 
 @shared_task
-@redis_lock('schedule_trigger_heavy_unified_connectors', 60 * 60)
+@redis_lock('schedule_trigger_super_heavy_unified_connectors', 60 * 60)
 def schedule_trigger_super_heavy_unified_connectors():
     # NOTE: Process connectors sources which have runtime <= 1 hour and was processed 24 hours ago.
     trigger_connector_sources(


### PR DESCRIPTION
Addresses
- https://github.com/the-deep/server/issues/1410

## Changes

- Add remaining_lead_extract task to Celery task registry
- Fix task ID to differentiate heavy and super heavy unified connectors trigger

## This PR doesn't introduce any:

- [x] temporary files, auto-generated files or secret keys
- [x] n+1 queries
- [x] flake8 issues
- [x] `print`
- [x] typos
- [x] unwanted comments

## This PR contains valid:

- [ ] tests
- [ ] permission checks (tests here too)
- [ ] translations