### PR TITLE
assessment-dashboard filter field changes from created_at to publicat…

### DIFF
--- a/apps/assessment_registry/dashboard_schema.py
+++ b/apps/assessment_registry/dashboard_schema.py
@@ -50,7 +50,7 @@ def node_cache(cache_key):
     )
 
 
-def get_global_filters(_filter: dict, date_field="created_at"):
+def get_global_filters(_filter: dict, date_field="publication_date"):
     return {
         f"{date_field}__gte": _filter["date_from"],
         f"{date_field}__lte": _filter["date_to"],
@@ -532,7 +532,7 @@ class AssessmentDashboardStatisticsType(graphene.ObjectType):
         ).values('focus').order_by('focus').annotate(
             count=Count('id')
         ).values('focus', 'count').annotate(
-            date=TruncDay('created_at')
+            date=TruncDay('publication_date')
         ).values('focus', 'count', 'date')
 
     @staticmethod
@@ -543,7 +543,7 @@ class AssessmentDashboardStatisticsType(graphene.ObjectType):
         ).values('affected_group').order_by('affected_group').annotate(
             count=Count('id')
         ).values('affected_group', 'count').annotate(
-            date=TruncDay('created_at')
+            date=TruncDay('publication_date')
         ).values('affected_group', 'count', 'date')
 
     @staticmethod
@@ -554,7 +554,7 @@ class AssessmentDashboardStatisticsType(graphene.ObjectType):
         ).values('sector').order_by('sector').annotate(
             count=Count('id')
         ).values('sector', 'count').annotate(
-            date=TruncDay('created_at')
+            date=TruncDay('publication_date')
         ).values('sector', 'count', 'date')
 
     @staticmethod
@@ -565,7 +565,7 @@ class AssessmentDashboardStatisticsType(graphene.ObjectType):
         ).values('protection_management').order_by('protection_management').annotate(
             count=Count('id')
         ).values('protection_management', 'count').annotate(
-            date=TruncDay('created_at')
+            date=TruncDay('publication_date')
         ).values('protection_management', 'count', 'date')
 
     @staticmethod
@@ -604,7 +604,7 @@ class AssessmentDashboardStatisticsType(graphene.ObjectType):
     @node_cache(CacheKey.AssessmentDashboard.ASSESSMENT_AFFECTED_GROUP_AND_GEOAREA)
     def resolve_assessment_per_affected_group_and_geoarea(root: AssessmentDashboardStat, info):
         return (
-            root.assessment_registry_qs.values("locations", date=TruncDay("created_at"))
+            root.assessment_registry_qs.values("locations", date=TruncDay("publication_date"))
             .annotate(
                 geo_area=models.F("locations"),
                 count=Count("id"),
@@ -637,7 +637,7 @@ class AssessmentDashboardStatisticsType(graphene.ObjectType):
             AssessmentRegistryOrganization.objects.filter(
                 organization_type=AssessmentRegistryOrganization.Type.LEAD_ORGANIZATION
             )
-            .values(date=TruncDay("assessment_registry__created_at"))
+            .values(date=TruncDay("assessment_registry__publication_date"))
             .filter(assessment_registry__in=root.assessment_registry_qs)
             .annotate(count=Count("organization"))
             .values("organization", "count", "date")
@@ -648,7 +648,7 @@ class AssessmentDashboardStatisticsType(graphene.ObjectType):
     @node_cache(CacheKey.AssessmentDashboard.ASSESSMENT_PER_DATA_COLLECTION_TECHNIQUE)
     def resolve_assessment_per_datatechnique(root: AssessmentDashboardStat, info):
         return (
-            root.methodology_attribute_qs.values(date=TruncDay("assessment_registry__created_at"))
+            root.methodology_attribute_qs.values(date=TruncDay("assessment_registry__publication_date"))
             .annotate(count=Count("data_collection_technique"))
             .values("data_collection_technique", "count", "date")
             .order_by("data_collection_technique")
@@ -658,7 +658,7 @@ class AssessmentDashboardStatisticsType(graphene.ObjectType):
     @node_cache(CacheKey.AssessmentDashboard.ASSESSMENT_PER_UNIT_ANALYSIS)
     def resolve_assessment_per_unit_of_analysis(root: AssessmentDashboardStat, info):
         return (
-            root.methodology_attribute_qs.values(date=TruncDay("assessment_registry__created_at"))
+            root.methodology_attribute_qs.values(date=TruncDay("assessment_registry__publication_date"))
             .annotate(count=Count("unit_of_analysis"))
             .values("unit_of_analysis", "count", "date")
             .order_by("unit_of_analysis")
@@ -668,7 +668,7 @@ class AssessmentDashboardStatisticsType(graphene.ObjectType):
     @node_cache(CacheKey.AssessmentDashboard.ASSESSMENT_PER_UNIT_REPORTING)
     def resolve_assessment_per_unit_of_reporting(root: AssessmentDashboardStat, info):
         return (
-            root.methodology_attribute_qs.values(date=TruncDay("assessment_registry__created_at"))
+            root.methodology_attribute_qs.values(date=TruncDay("assessment_registry__publication_date"))
             .annotate(count=Count("unit_of_reporting"))
             .values("unit_of_reporting", "count", "date")
             .order_by("unit_of_reporting")
@@ -678,7 +678,7 @@ class AssessmentDashboardStatisticsType(graphene.ObjectType):
     @node_cache(CacheKey.AssessmentDashboard.ASSESSMENT_PER_SAMPLE_APPROACH)
     def resolve_assessment_per_sampling_approach(root: AssessmentDashboardStat, info):
         return (
-            root.methodology_attribute_qs.values(date=TruncDay("assessment_registry__created_at"))
+            root.methodology_attribute_qs.values(date=TruncDay("assessment_registry__publication_date"))
             .annotate(count=Count("sampling_approach"))
             .values("sampling_approach", "count", "date")
             .order_by("sampling_approach")
@@ -688,7 +688,7 @@ class AssessmentDashboardStatisticsType(graphene.ObjectType):
     @node_cache(CacheKey.AssessmentDashboard.ASSESSMENT_PER_PROXIMITY)
     def resolve_assessment_per_proximity(root: AssessmentDashboardStat, info):
         return (
-            root.methodology_attribute_qs.values(date=TruncDay("assessment_registry__created_at"))
+            root.methodology_attribute_qs.values(date=TruncDay("assessment_registry__publication_date"))
             .annotate(count=Count("proximity"))
             .values("proximity", "count", "date")
             .order_by("proximity")
@@ -698,7 +698,7 @@ class AssessmentDashboardStatisticsType(graphene.ObjectType):
     @node_cache(CacheKey.AssessmentDashboard.SAMPLE_SIZE_PER_DATA_COLLECTION_TECHNIQUE)
     def resolve_sample_size_per_data_collection_technique(root: AssessmentDashboardStat, info):
         return (
-            root.methodology_attribute_qs.values(date=TruncDay("assessment_registry__created_at"))
+            root.methodology_attribute_qs.values(date=TruncDay("assessment_registry__publication_date"))
             .annotate(sampling_size=Sum("sampling_size"))
             .values("sampling_size", "data_collection_technique", "date")
             .order_by("data_collection_technique")

--- a/apps/assessment_registry/tests/test_dashboard_schema.py
+++ b/apps/assessment_registry/tests/test_dashboard_schema.py
@@ -185,7 +185,7 @@ class AssessmentDashboardQuerySchema(GraphQLTestCase):
             limitations="test",
             objectives="test",
             noOfPages=10,
-            publicationDate="2023-01-01",
+            publicationDate=str(date.today()),
             sampling="test",
             language=[self.genum(AssessmentRegistry.Language.ENGLISH), self.genum(AssessmentRegistry.Language.SPANISH)],
             bgCountries=[self.region.id],
@@ -337,6 +337,7 @@ class AssessmentDashboardQuerySchema(GraphQLTestCase):
 
         self.force_login(self.member_user)
         content = _query_check(filter)["data"]["project"]["assessmentDashboardStatistics"]
+        print(content)
         # assessment dashboard tab 1
         self.assertEqual(content["totalAssessment"], 1)
         self.assertEqual(content["totalCollectionTechnique"], 2)

--- a/apps/assessment_registry/tests/test_dashboard_schema.py
+++ b/apps/assessment_registry/tests/test_dashboard_schema.py
@@ -1,4 +1,4 @@
-from datetime import date, timedelta
+from datetime import date
 
 from utils.graphene.tests import GraphQLTestCase
 
@@ -185,7 +185,7 @@ class AssessmentDashboardQuerySchema(GraphQLTestCase):
             limitations="test",
             objectives="test",
             noOfPages=10,
-            publicationDate=str(date.today()),
+            publicationDate='2023-01-01',
             sampling="test",
             language=[self.genum(AssessmentRegistry.Language.ENGLISH), self.genum(AssessmentRegistry.Language.SPANISH)],
             bgCountries=[self.region.id],
@@ -333,11 +333,10 @@ class AssessmentDashboardQuerySchema(GraphQLTestCase):
         def _query_check(filter=None, **kwargs):
             return self.query_check(query, variables={"filter": filter, "id": self.project1.id}, **kwargs)
 
-        filter = {"dateFrom": "2019-01-01", "dateTo": str(date.today() + timedelta(1))}
+        filter = {"dateFrom": "2019-01-01", "dateTo": "2023-01-01"}
 
         self.force_login(self.member_user)
         content = _query_check(filter)["data"]["project"]["assessmentDashboardStatistics"]
-        print(content)
         # assessment dashboard tab 1
         self.assertEqual(content["totalAssessment"], 1)
         self.assertEqual(content["totalCollectionTechnique"], 2)
@@ -352,8 +351,7 @@ class AssessmentDashboardQuerySchema(GraphQLTestCase):
         self.assertEqual(content["assessmentGeographicAreas"][0]["geoArea"], str(self.geo_area1.id))
         self.assertEqual(content["assessmentGeographicAreas"][1]["geoArea"], str(self.geo_area2.id))
         self.assertEqual(content["assessmentByOverTime"][0]["count"], 1)
-        self.assertEqual(content["assessmentByOverTime"][0]["date"], str(date.today()))
-        self.assertEqual(content["assessmentPerFrameworkPillar"][0]["date"], str(date.today()))
+        self.assertEqual(content["assessmentPerFrameworkPillar"][0]["date"], "2023-01-01")
         # assessment dashboard tab 2
         self.assertEqual(
             content['assessmentByDataCollectionTechniqueAndGeolocation'][0]['dataCollectionTechnique'],


### PR DESCRIPTION
## Changes
- assessment dashboard filter field changes from created at to publication date 
- publication date field used only in Tab1 and Tab2, what is assessed , how is assessed respectively 

## This PR doesn't introduce any:

- [x] temporary files, auto-generated files or secret keys
- [x] n+1 queries
- [x] flake8 issues
- [x] `print`
- [x] typos
- [x] unwanted comments

## This PR contains valid:

- [ ] tests
- [ ] permission checks (tests here too)
- [ ] translations
