### PR TITLE
Add ignore ids filter in draft entries query

### DIFF
--- a/apps/assisted_tagging/filters.py
+++ b/apps/assisted_tagging/filters.py
@@ -1,7 +1,11 @@
 import django_filters
 
 from .models import DraftEntry
-from utils.graphene.filters import IDFilter, MultipleInputFilter
+from utils.graphene.filters import (
+    IDFilter,
+    MultipleInputFilter,
+    IDListFilter,
+)
 from .enums import (
     DraftEntryTypeEnum
 )
@@ -10,8 +14,14 @@ from .enums import (
 class DraftEntryFilterSet(django_filters.FilterSet):
     lead = IDFilter(field_name='lead')
     draft_entry_types = MultipleInputFilter(DraftEntryTypeEnum, field_name='type')
+    ignore_ids = IDListFilter(method='filter_ignore_draft_ids', help_text='Ids are filtered out.')
     is_discarded = django_filters.BooleanFilter()
 
     class Meta:
         model = DraftEntry
         fields = ()
+
+    def filter_ignore_draft_ids(self, qs, _, value):
+        if value is None:
+            return qs
+        return qs.exclude(id__in=value)

--- a/schema.graphql
+++ b/schema.graphql
@@ -2498,7 +2498,7 @@ type AssistedTaggingPredictionType {
 
 type AssistedTaggingQueryType {
   draftEntry(id: ID!): DraftEntryType
-  draftEntries(lead: ID, draftEntryTypes: [DraftEntryTypeEnum!], isDiscarded: Boolean, page: Int = 1, pageSize: Int): DraftEntryListType
+  draftEntries(lead: ID, draftEntryTypes: [DraftEntryTypeEnum!], ignoreIds: [ID!], isDiscarded: Boolean, page: Int = 1, pageSize: Int): DraftEntryListType
 }
 
 type AssistedTaggingRootQueryType {


### PR DESCRIPTION
## Changes

* Add ignore ids filter in draft entries query

Mention related users here if any.

## This PR doesn't introduce any:

- [x] temporary files, auto-generated files or secret keys
- [x] n+1 queries
- [x] flake8 issues
- [x] `print`
- [x] typos
- [x] unwanted comments

## This PR contains valid:

- [x] tests
- [x] permission checks (tests here too)
- [x] translations