### PR TITLE
Separate project memebership and af membership from admin panel

### DIFF
--- a/apps/analysis_framework/admin.py
+++ b/apps/analysis_framework/admin.py
@@ -21,12 +21,7 @@ from .models import (
     Filter,
     Exportable,
 )
-
-
-class AnalysisFrameworkMemebershipInline(admin.TabularInline):
-    model = AnalysisFrameworkMembership
-    extra = 0
-    autocomplete_fields = ('added_by', 'member',)
+from admin_auto_filters.filters import AutocompleteFilterFactory
 
 
 class WidgetInline(StackedInline):
@@ -70,7 +65,7 @@ for model in [Section, Widget, Filter, Exportable, FrameworkQuestion]:
 @admin.register(AnalysisFramework)
 class AnalysisFrameworkAdmin(VersionAdmin):
     readonly_fields = ['is_private']
-    inlines = [AnalysisFrameworkMemebershipInline, SectionInline, WidgetInline]
+    inlines = [SectionInline, WidgetInline]
     search_fields = ('title',)
     list_filter = ('is_private', 'assisted_tagging_enabled',)
     custom_inlines = [
@@ -119,3 +114,22 @@ class AnalysisFrameworkRoleAdmin(admin.ModelAdmin):
 @admin.register(AnalysisFrameworkTag)
 class AnalysisFrameworkTagAdmin(admin.ModelAdmin):
     list_display = ('id', 'title',)
+
+
+@admin.register(AnalysisFrameworkMembership)
+class AnalysisFrameworkMembershipAdmin(admin.ModelAdmin):
+    search_fields = ('framework__title',)
+    autocomplete_fields = ('added_by', 'member',)
+    serch_fields = ['analysis_framework__title']
+    list_display = ['framework', 'member', 'role']
+    list_filter = (
+        AutocompleteFilterFactory('Project', 'framework__project'),
+        AutocompleteFilterFactory('AnalysisFramework', 'framework'),
+        'framework__is_private'
+    )
+
+    def get_readonly_fields(self, request, obj=None):
+        # editing an existing object
+        if obj:
+            return self.readonly_fields + ('framework', )
+        return self.readonly_fields

--- a/apps/project/admin.py
+++ b/apps/project/admin.py
@@ -61,12 +61,6 @@ def trigger_project_stat_cache_calc():
     return action
 
 
-class ProjectMembershipInline(admin.TabularInline):
-    model = ProjectMembership
-    extra = 0
-    autocomplete_fields = ('added_by', 'linked_group', 'member',)
-
-
 class ProjectUserGroupMembershipInline(admin.TabularInline):
     model = ProjectUserGroupMembership
     extra = 0
@@ -108,8 +102,7 @@ class ProjectAdmin(VersionAdmin):
         'is_deleted',
     )
     actions = [trigger_project_stat_cache_calc()]
-    inlines = [ProjectMembershipInline,
-               ProjectUserGroupMembershipInline,
+    inlines = [ProjectUserGroupMembershipInline,
                ProjectJoinRequestInline,
                ProjectOrganizationInline]
 
@@ -219,3 +212,19 @@ class ProjectChangeLogAdmin(admin.ModelAdmin):
 @admin.register(ProjectPinned)
 class ProjectPinnedAdmin(admin.ModelAdmin):
     list_display = ('id', 'project', 'user', 'order')
+
+
+@admin.register(ProjectMembership)
+class ProjectMembershipAdmin(admin.ModelAdmin):
+    search_fields = ['project__title']
+    autocomplete_fields = ('added_by', 'linked_group', 'member', 'project')
+    list_filter = (
+        AutocompleteFilterFactory('Project', 'project'),
+    )
+    list_display = ['project', 'member']
+
+    def get_readonly_fields(self, request, obj=None):
+        # editing an existing object
+        if obj:
+            return self.readonly_fields + ('project', )
+        return self.readonly_fields


### PR DESCRIPTION
Addresses 
- https://github.com/the-deep/server/issues/1487

## Expected Result
The new group should be created successfully with the specified name and description. The group should have permissions to view all models, with additional add/edit permissions granted specifically for the "Project Membership" and "Analysis Framework" models.


## This PR doesn't introduce any:

- [x] temporary files, auto-generated files or secret keys
- [x] n+1 queries
- [x] flake8 issues
- [x] `print`
- [x] typos
- [x] unwanted comments

## This PR contains valid:

- [ ] tests
- [ ] permission checks (tests here too)
- [ ] translations
