### PR TITLE
OCR filter

### DIFF
--- a/apps/lead/filter_set.py
+++ b/apps/lead/filter_set.py
@@ -556,6 +556,9 @@ class LeadGroupGQFilterSet(UserResourceGqlFilterSet):
 class LeadPreviewAttachmentGQFilterSet(UserResourceGqlFilterSet):
     type = MultipleInputFilter(LeadPreviewAttachmentTypeEnum, field_name='type')
     exclude_attachment_ids = IDListFilter(method='filter_exclude_lead_attachment_ids')
+    exclude_leadattachment_created_entries = django_filters.BooleanFilter(
+        method='filter_exclude_leadattachment_created_entries'
+    )
 
     class Meta:
         model = LeadPreviewAttachment
@@ -563,11 +566,18 @@ class LeadPreviewAttachmentGQFilterSet(UserResourceGqlFilterSet):
             'lead',
             'page_number',
             'exclude_attachment_ids',
+            'exclude_leadattachment_created_entries'
         ]
 
     def filter_exclude_lead_attachment_ids(self, qs, _, value):
         if value:
             qs = qs.exclude(id__in=value)
+            return qs
+        return qs
+
+    def filter_exclude_leadattachment_created_entries(self, qs, _, value):
+        if value:
+            qs = qs.exclude(lead__entry__isnull=value)
             return qs
         return qs
 

--- a/schema.graphql
+++ b/schema.graphql
@@ -5397,7 +5397,7 @@ type ProjectDetailType {
   leadGroups(createdAt: DateTime, createdAtGte: DateTime, createdAtLte: DateTime, modifiedAt: DateTime, modifiedAtGte: DateTime, modifiedAtLte: DateTime, createdBy: [ID!], modifiedBy: [ID!], search: String, page: Int = 1, ordering: String, pageSize: Int): LeadGroupListType
   emmEntities(name: String, page: Int = 1, ordering: String, pageSize: Int): EmmEntityListType
   leadEmmTriggers(lead: ID, emmKeyword: String, emmRiskFactor: String, count: Int, page: Int = 1, ordering: String, pageSize: Int): LeadEmmTriggerListType
-  leadPreviewAttachments(lead: ID, pageNumber: Int, excludeAttachmentIds: [ID!], createdAt: DateTime, createdAtGte: DateTime, createdAtLte: DateTime, modifiedAt: DateTime, modifiedAtGte: DateTime, modifiedAtLte: DateTime, createdBy: [ID!], modifiedBy: [ID!], type: [LeadPreviewAttachmentTypeEnum!], page: Int = 1, ordering: String, pageSize: Int): LeadPreviewAttachmentListType
+  leadPreviewAttachments(lead: ID, pageNumber: Int, excludeAttachmentIds: [ID!], excludeLeadattachmentCreatedEntries: Boolean, createdAt: DateTime, createdAtGte: DateTime, createdAtLte: DateTime, modifiedAt: DateTime, modifiedAtGte: DateTime, modifiedAtLte: DateTime, createdBy: [ID!], modifiedBy: [ID!], type: [LeadPreviewAttachmentTypeEnum!], page: Int = 1, ordering: String, pageSize: Int): LeadPreviewAttachmentListType
   emmKeywords: [EmmKeyWordType!]
   emmRiskFactors: [EmmKeyRiskFactorType!]
   userSavedLeadFilter: UserSavedLeadFilterType


### PR DESCRIPTION
Implement GraphQL filters for LeadPreviewAttachment by type and excluding specific IDs.

## This PR doesn't introduce any:

- [x] temporary files, auto-generated files or secret keys
- [x] n+1 queries
- [x] flake8 issues
- [x] `print`
- [x] typos
- [x] unwanted comments

## This PR contains valid:

- [ ] tests
- [ ] permission checks (tests here too)
- [ ] translations
