### PR TITLE
Add is_published filter in regionlist

### DIFF
--- a/apps/geo/filter_set.py
+++ b/apps/geo/filter_set.py
@@ -52,7 +52,7 @@ class RegionFilterSet(UserResourceFilterSet):
 
     class Meta:
         model = Region
-        fields = ['id', 'code', 'title', 'public', 'project',
+        fields = ['id', 'code', 'title', 'public', 'project', 'is_published',
                   'created_at', 'created_by', 'modified_at', 'modified_by']
         filter_overrides = {
             models.CharField: {

--- a/schema.graphql
+++ b/schema.graphql
@@ -5875,7 +5875,7 @@ type Query {
   notifications(timestamp: DateTime, timestampLte: DateTime, timestampGte: DateTime, isPending: Boolean, notificationType: NotificationTypeEnum, status: NotificationStatusEnum, page: Int = 1, ordering: String, pageSize: Int): NotificationListType
   assignments(project: ID, isDone: Boolean, page: Int = 1, ordering: String, pageSize: Int): AssignmentListType
   region(id: ID!): RegionDetailType
-  regions(id: Float, code: String, title: String, public: Boolean, project: [ID], createdAt: DateTime, createdBy: [ID], modifiedAt: DateTime, modifiedBy: [ID], createdAt_Lt: Date, createdAt_Gte: Date, modifiedAt_Lt: Date, modifiedAt_Gt: Date, excludeProject: [ID!], search: String, page: Int = 1, ordering: String, pageSize: Int): RegionListType
+  regions(id: Float, code: String, title: String, public: Boolean, project: [ID], isPublished: Boolean, createdAt: DateTime, createdBy: [ID], modifiedAt: DateTime, modifiedBy: [ID], createdAt_Lt: Date, createdAt_Gte: Date, modifiedAt_Lt: Date, modifiedAt_Gt: Date, excludeProject: [ID!], search: String, page: Int = 1, ordering: String, pageSize: Int): RegionListType
   organization(id: ID!): OrganizationType
   organizations(id: Float, verified: Boolean, search: String, usedInProjectByLead: ID, usedInProjectByAssesment: ID, ordering: [OrganizationOrderingEnum!], page: Int = 1, pageSize: Int): OrganizationListType
   publicOrganizations(id: Float, verified: Boolean, search: String, usedInProjectByLead: ID, usedInProjectByAssesment: ID, ordering: [OrganizationOrderingEnum!], page: Int = 1, pageSize: Int): PublicOrganizationListObjectType


### PR DESCRIPTION
Add `is_published` filter to the RegionList view, allowing users to easily filter regions based on their publication status

## Changes

* Detailed list or prose of changes
* Breaking changes
* Changes to configurations

Mention related users here if any.

## This PR doesn't introduce any:

- [x] temporary files, auto-generated files or secret keys
- [x] n+1 queries
- [x] flake8 issues
- [x] `print`
- [x] typos
- [x] unwanted comments

## This PR contains valid:

- [ ] tests
- [ ] permission checks (tests here too)
- [ ] translations
