### PR TITLE
Replace Nested DictField in model_tags

### DIFF
--- a/apps/deepl_integration/serializers.py
+++ b/apps/deepl_integration/serializers.py
@@ -264,7 +264,7 @@ class AssistedTaggingDraftEntryPredictionCallbackSerializer(BaseCallbackSerializ
 
 
 class LlmAssistedTaggingDraftEntryPredictionCallbackSerializer(BaseCallbackSerializer):
-    model_tags = serializers.DictField(child=serializers.DictField())
+    model_tags = serializers.DictField()
     prediction_status = serializers.BooleanField()
     model_info = serializers.DictField()
     nlp_handler = LlmAssistedTaggingDraftEntryHandler


### PR DESCRIPTION
Addresses 
 - https://github.com/the-deep/server/issues/1554

## Changes
* Remove child dict field from assisted tagging serializer


Mention related users here if any.

## This PR doesn't introduce any:

- [x] temporary files, auto-generated files or secret keys
- [x] n+1 queries
- [x] flake8 issues
- [x] `print`
- [x] typos
- [x] unwanted comments

## This PR contains valid:

- [ ] tests
- [ ] permission checks (tests here too)
- [ ] translations
